### PR TITLE
Setup code coverage reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <surefire-plugin.version>3.0.0-M8</surefire-plugin.version>
     <checkstyle-plugin.version>3.2.1</checkstyle-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-    <jacoco-plugin.version>0.8.8</jacoco-plugin.version>
+    <jacoco-plugin.version>0.8.9</jacoco-plugin.version>
     <checkstyle.version>10.6.0</checkstyle.version>
 
     <testcontainers.version>1.17.6</testcontainers.version>
@@ -134,7 +134,49 @@
           </execution>
         </executions>
       </plugin>
-
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>coverage</id>
+      <!-- uncomment when there is a @QuarkusTest being run -->
+      <!-- <dependencies>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-jacoco</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies> -->
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>${jacoco-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>default-prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+                <!-- uncomment this config when there is a @QuarkusTest being run -->
+                <!-- <configuration>
+                  <exclClassLoaders>*QuarkusClassLoader</exclClassLoaders>
+                  <destFile>${project.build.directory}/jacoco-quarkus.exec</destFile>
+                  <append>true</append>
+                </configuration> -->
+              </execution>
+              <execution>
+                <id>default-report</id>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+                <phase>test</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -139,14 +139,13 @@
   <profiles>
     <profile>
       <id>coverage</id>
-      <!-- uncomment when there is a @QuarkusTest being run -->
-      <!-- <dependencies>
+      <dependencies>
         <dependency>
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-jacoco</artifactId>
           <scope>test</scope>
         </dependency>
-      </dependencies> -->
+      </dependencies>
       <build>
         <plugins>
           <plugin>
@@ -159,12 +158,11 @@
                 <goals>
                   <goal>prepare-agent</goal>
                 </goals>
-                <!-- uncomment this config when there is a @QuarkusTest being run -->
-                <!-- <configuration>
+                <configuration>
                   <exclClassLoaders>*QuarkusClassLoader</exclClassLoaders>
                   <destFile>${project.build.directory}/jacoco-quarkus.exec</destFile>
                   <append>true</append>
-                </configuration> -->
+                </configuration>
               </execution>
               <execution>
                 <id>default-report</id>


### PR DESCRIPTION
This PR addresses https://github.com/RedHatInsights/insights-runtimes-inventory/issues/55, in which it'd be nice to have a code coverage report. I put it behind a maven profile so it can be run when desired.

I took a look through the Quarkus guide for test coverage [[0]](https://quarkus.io/guides/tests-with-coverage), and there's a quarkus-jacoco extension that reports coverage for @QuakusTest classes. The extension can also work with the jacoco-maven-plugin, but this requires a bit of additional config to ignore the @QuarkusTest classes [[1]](https://quarkus.io/guides/tests-with-coverage#coverage-for-tests-not-using-quarkustest). This config will only work if there is at least one @QuarkusTest being run, so at the moment I have it (and the extension) commented out.

Edit: QuarkusTest annotation added in https://github.com/RedHatInsights/insights-runtimes-inventory/pull/60, can revisit and uncomment the extension once it's been integrated.

I also bumped the jacoco version to 8.0.9 to match the Quarkus version (3.0.4.Final) that this repo is currently using [[2]](https://github.com/quarkusio/quarkus/blob/3.0.4.Final/pom.xml#L70), so it should align with the quarkus-jacoco extension.

Example coverage report:
![Screenshot from 2023-08-04 16-16-10](https://github.com/RedHatInsights/insights-runtimes-inventory/assets/10425301/9eceefe7-796f-4e91-89fe-666ddaf15762)

[0] https://quarkus.io/guides/tests-with-coverage
[1] https://quarkus.io/guides/tests-with-coverage#coverage-for-tests-not-using-quarkustest
[2] https://github.com/quarkusio/quarkus/blob/3.0.4.Final/pom.xml#L70