### PR TITLE
Add test cases using TestContainers

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -141,7 +141,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mockserver</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -153,7 +152,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -163,7 +161,6 @@
       <artifactId>spotless-maven-plugin</artifactId>
       <version>${spotless-maven-plugin.version}</version>
     </dependency>
-
   </dependencies>
 
   <build>

--- a/events/pom.xml
+++ b/events/pom.xml
@@ -130,6 +130,16 @@
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.groovy</groupId>
+          <artifactId>groovy</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.groovy</groupId>
+          <artifactId>groovy-xml</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>
@@ -139,7 +149,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mockserver</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -151,7 +160,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/events/src/main/java/com/redhat/runtimes/inventory/events/EventConsumer.java
+++ b/events/src/main/java/com/redhat/runtimes/inventory/events/EventConsumer.java
@@ -60,6 +60,8 @@ public class EventConsumer {
 
   @Inject EntityManager entityManager;
 
+  private static HttpClient httpClient;
+
   private ArchiveAnnouncementParser jsonParser = new ArchiveAnnouncementParser();
 
   private Counter rejectedCounter;
@@ -449,6 +451,10 @@ public class EventConsumer {
     }
   }
 
+  static void setHttpClient(HttpClient httpClient) {
+    EventConsumer.httpClient = httpClient;
+  }
+
   static String getJsonFromS3(String urlStr) {
     try {
       var uri = new URL(urlStr).toURI();
@@ -456,8 +462,10 @@ public class EventConsumer {
       var request = requestBuilder.GET().build();
       Log.debugf("Issuing a HTTP POST request to %s", request);
 
-      var client = HttpClient.newBuilder().build();
-      var response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+      if (httpClient == null) {
+        httpClient = HttpClient.newBuilder().build();
+      }
+      var response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
       Log.debugf("S3 HTTP Client status: %s", response.statusCode());
 
       return unzipJson(response.body());

--- a/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerIntegrationTest.java
+++ b/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerIntegrationTest.java
@@ -1,0 +1,127 @@
+/* Copyright (C) Red Hat 2023 */
+package com.redhat.runtimes.inventory.events;
+
+import static com.redhat.runtimes.inventory.events.EventConsumer.CONSUMED_TIMER_NAME;
+import static com.redhat.runtimes.inventory.events.EventConsumer.INGRESS_CHANNEL;
+import static com.redhat.runtimes.inventory.events.EventConsumer.PROCESSING_EXCEPTION_COUNTER_NAME;
+import static com.redhat.runtimes.inventory.events.EventConsumer.jvmInstanceOf;
+import static com.redhat.runtimes.inventory.events.Utils.readBytesFromResources;
+import static com.redhat.runtimes.inventory.events.Utils.readFromResources;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.redhat.runtimes.inventory.models.InsightsMessage;
+import com.redhat.runtimes.inventory.models.JvmInstance;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import jakarta.enterprise.inject.Any;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+@Tag("integration-tests")
+public class EventConsumerIntegrationTest {
+
+  @Inject EntityManager entityManager;
+
+  @Inject @Any InMemoryConnector inMemoryConnector;
+
+  @Inject MicrometerAssertionHelper micrometerAssertionHelper;
+
+  @BeforeEach
+  void beforeEach() {
+    micrometerAssertionHelper.saveCounterValuesBeforeTest(PROCESSING_EXCEPTION_COUNTER_NAME);
+    micrometerAssertionHelper.removeDynamicTimer(CONSUMED_TIMER_NAME);
+  }
+
+  @AfterEach
+  void clear() {
+    micrometerAssertionHelper.clearSavedValues();
+    micrometerAssertionHelper.removeDynamicTimer(CONSUMED_TIMER_NAME);
+  }
+
+  @Test
+  @Transactional
+  @SuppressWarnings("unchecked")
+  void testValidJvmInstancePayload() throws IOException, InterruptedException {
+    clearTables();
+    HttpClient mockClient = mock(HttpClient.class);
+    HttpResponse<byte[]> mockResponse = mock(HttpResponse.class);
+    byte[] buffy = readBytesFromResources("jdk8_MWTELE-66.gz");
+    when(mockClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(mockResponse);
+    when(mockResponse.body()).thenReturn(buffy);
+
+    EventConsumer.setHttpClient(mockClient);
+    String kafkaMessage = readFromResources("incoming_kafka1.json");
+    inMemoryConnector.source(INGRESS_CHANNEL).send(kafkaMessage);
+
+    micrometerAssertionHelper.awaitAndAssertTimerIncrement(CONSUMED_TIMER_NAME, 1);
+    micrometerAssertionHelper.assertCounterIncrement(PROCESSING_EXCEPTION_COUNTER_NAME, 0);
+    assertEquals(1L, jvminstance_count());
+  }
+
+  @Test
+  void testInvalidPayload() throws IOException {
+    inMemoryConnector.source(INGRESS_CHANNEL).send("not a real payload");
+    micrometerAssertionHelper.awaitAndAssertTimerIncrement(CONSUMED_TIMER_NAME, 1);
+    micrometerAssertionHelper.assertCounterIncrement(PROCESSING_EXCEPTION_COUNTER_NAME, 1);
+  }
+
+  @Test
+  @Transactional
+  void testBasicPostgresTransactions() throws IOException {
+    clearTables();
+    ArchiveAnnouncement dummy = new ArchiveAnnouncement();
+    dummy.setAccountId("dummy account id");
+    dummy.setOrgId("dummy org");
+    dummy.setTimestamp(LocalDateTime.now());
+
+    byte[] buffy = readBytesFromResources("jdk8_MWTELE-66.gz");
+    String json = EventConsumer.unzipJson(buffy);
+
+    InsightsMessage msg = jvmInstanceOf(dummy, json);
+    assertTrue(msg instanceof JvmInstance);
+    JvmInstance inst = (JvmInstance) msg;
+
+    assertEquals(0L, jvminstance_count());
+    assertEquals(0L, jarhash_count());
+
+    entityManager.persist(inst);
+    assertEquals(1L, jvminstance_count());
+    assertEquals(1L, jarhash_count());
+
+    entityManager.remove(inst);
+    assertEquals(0L, jvminstance_count());
+    assertEquals(0L, jarhash_count());
+  }
+
+  private void clearTables() {
+    entityManager.createNativeQuery("DELETE FROM jar_hash").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM jvm_instance").executeUpdate();
+  }
+
+  private Long jvminstance_count() {
+    return entityManager
+        .createQuery("SELECT COUNT (*) FROM JvmInstance", Long.class)
+        .getSingleResult();
+  }
+
+  private Long jarhash_count() {
+    return entityManager.createQuery("SELECT COUNT (*) FROM JarHash", Long.class).getSingleResult();
+  }
+}

--- a/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerTest.java
+++ b/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerTest.java
@@ -1,62 +1,23 @@
 /* Copyright (C) Red Hat 2023 */
 package com.redhat.runtimes.inventory.events;
 
-import static com.redhat.runtimes.inventory.events.EventConsumer.CONSUMED_TIMER_NAME;
-import static com.redhat.runtimes.inventory.events.EventConsumer.INGRESS_CHANNEL;
-import static com.redhat.runtimes.inventory.events.EventConsumer.PROCESSING_EXCEPTION_COUNTER_NAME;
 import static com.redhat.runtimes.inventory.events.EventConsumer.eapInstanceOf;
 import static com.redhat.runtimes.inventory.events.EventConsumer.jvmInstanceOf;
 import static com.redhat.runtimes.inventory.events.Utils.readBytesFromResources;
 import static com.redhat.runtimes.inventory.events.Utils.readFromResources;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.runtimes.inventory.models.EapInstance;
-import com.redhat.runtimes.inventory.models.InsightsMessage;
 import com.redhat.runtimes.inventory.models.JvmInstance;
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.QuarkusTest;
-import io.smallrye.reactive.messaging.memory.InMemoryConnector;
-import jakarta.enterprise.inject.Any;
-import jakarta.inject.Inject;
-import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
 import java.io.IOException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.time.LocalDateTime;
 import java.util.Map;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@QuarkusTest
-@QuarkusTestResource(TestLifecycleManager.class)
 public class EventConsumerTest {
-
-  @Inject EntityManager entityManager;
-
-  @Inject @Any InMemoryConnector inMemoryConnector;
-
-  @Inject MicrometerAssertionHelper micrometerAssertionHelper;
-
-  @BeforeEach
-  void beforeEach() {
-    micrometerAssertionHelper.saveCounterValuesBeforeTest(PROCESSING_EXCEPTION_COUNTER_NAME);
-    micrometerAssertionHelper.removeDynamicTimer(CONSUMED_TIMER_NAME);
-  }
-
-  @AfterEach
-  void clear() {
-    micrometerAssertionHelper.clearSavedValues();
-    micrometerAssertionHelper.removeDynamicTimer(CONSUMED_TIMER_NAME);
-  }
 
   @Test
   public void testSimpleUnzip() throws IOException {
@@ -136,76 +97,5 @@ public class EventConsumerTest {
     assertNotNull(inst.getConfiguration().getInterfaces());
     assertNotNull(inst.getConfiguration().getPaths());
     assertNotNull(inst.getConfiguration().getSocketBindingGroups());
-  }
-
-  @Test
-  @Transactional
-  @SuppressWarnings("unchecked")
-  void testValidJvmInstancePayload() throws IOException, InterruptedException {
-    clearTables();
-    HttpClient mockClient = mock(HttpClient.class);
-    HttpResponse<byte[]> mockResponse = mock(HttpResponse.class);
-    byte[] buffy = readBytesFromResources("jdk8_MWTELE-66.gz");
-    when(mockClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
-        .thenReturn(mockResponse);
-    when(mockResponse.body()).thenReturn(buffy);
-
-    EventConsumer.setHttpClient(mockClient);
-    String kafkaMessage = readFromResources("incoming_kafka1.json");
-    inMemoryConnector.source(INGRESS_CHANNEL).send(kafkaMessage);
-
-    micrometerAssertionHelper.awaitAndAssertTimerIncrement(CONSUMED_TIMER_NAME, 1);
-    micrometerAssertionHelper.assertCounterIncrement(PROCESSING_EXCEPTION_COUNTER_NAME, 0);
-    assertEquals(1L, jvminstance_count());
-  }
-
-  @Test
-  void testInvalidPayload() throws IOException {
-    inMemoryConnector.source(INGRESS_CHANNEL).send("not a real payload");
-    micrometerAssertionHelper.awaitAndAssertTimerIncrement(CONSUMED_TIMER_NAME, 1);
-    micrometerAssertionHelper.assertCounterIncrement(PROCESSING_EXCEPTION_COUNTER_NAME, 1);
-  }
-
-  @Test
-  @Transactional
-  void testBasicPostgresTransactions() throws IOException {
-    clearTables();
-    ArchiveAnnouncement dummy = new ArchiveAnnouncement();
-    dummy.setAccountId("dummy account id");
-    dummy.setOrgId("dummy org");
-    dummy.setTimestamp(LocalDateTime.now());
-
-    byte[] buffy = readBytesFromResources("jdk8_MWTELE-66.gz");
-    String json = EventConsumer.unzipJson(buffy);
-
-    InsightsMessage msg = jvmInstanceOf(dummy, json);
-    assertTrue(msg instanceof JvmInstance);
-    JvmInstance inst = (JvmInstance) msg;
-
-    assertEquals(0L, jvminstance_count());
-    assertEquals(0L, jarhash_count());
-
-    entityManager.persist(inst);
-    assertEquals(1L, jvminstance_count());
-    assertEquals(1L, jarhash_count());
-
-    entityManager.remove(inst);
-    assertEquals(0L, jvminstance_count());
-    assertEquals(0L, jarhash_count());
-  }
-
-  private void clearTables() {
-    entityManager.createNativeQuery("DELETE FROM jar_hash").executeUpdate();
-    entityManager.createNativeQuery("DELETE FROM jvm_instance").executeUpdate();
-  }
-
-  private Long jvminstance_count() {
-    return entityManager
-        .createQuery("SELECT COUNT (*) FROM JvmInstance", Long.class)
-        .getSingleResult();
-  }
-
-  private Long jarhash_count() {
-    return entityManager.createQuery("SELECT COUNT (*) FROM JarHash", Long.class).getSingleResult();
   }
 }

--- a/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerTest.java
+++ b/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerTest.java
@@ -10,7 +10,6 @@ import static com.redhat.runtimes.inventory.events.Utils.readBytesFromResources;
 import static com.redhat.runtimes.inventory.events.Utils.readFromResources;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerTest.java
+++ b/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerTest.java
@@ -1,23 +1,63 @@
 /* Copyright (C) Red Hat 2023 */
 package com.redhat.runtimes.inventory.events;
 
+import static com.redhat.runtimes.inventory.events.EventConsumer.CONSUMED_TIMER_NAME;
+import static com.redhat.runtimes.inventory.events.EventConsumer.INGRESS_CHANNEL;
+import static com.redhat.runtimes.inventory.events.EventConsumer.PROCESSING_EXCEPTION_COUNTER_NAME;
 import static com.redhat.runtimes.inventory.events.EventConsumer.eapInstanceOf;
 import static com.redhat.runtimes.inventory.events.EventConsumer.jvmInstanceOf;
 import static com.redhat.runtimes.inventory.events.Utils.readBytesFromResources;
 import static com.redhat.runtimes.inventory.events.Utils.readFromResources;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.runtimes.inventory.models.EapInstance;
+import com.redhat.runtimes.inventory.models.InsightsMessage;
 import com.redhat.runtimes.inventory.models.JvmInstance;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import jakarta.enterprise.inject.Any;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
 import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.time.LocalDateTime;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
 public class EventConsumerTest {
+
+  @Inject EntityManager entityManager;
+
+  @Inject @Any InMemoryConnector inMemoryConnector;
+
+  @Inject MicrometerAssertionHelper micrometerAssertionHelper;
+
+  @BeforeEach
+  void beforeEach() {
+    micrometerAssertionHelper.saveCounterValuesBeforeTest(PROCESSING_EXCEPTION_COUNTER_NAME);
+    micrometerAssertionHelper.removeDynamicTimer(CONSUMED_TIMER_NAME);
+  }
+
+  @AfterEach
+  void clear() {
+    micrometerAssertionHelper.clearSavedValues();
+    micrometerAssertionHelper.removeDynamicTimer(CONSUMED_TIMER_NAME);
+  }
 
   @Test
   public void testSimpleUnzip() throws IOException {
@@ -97,5 +137,76 @@ public class EventConsumerTest {
     assertNotNull(inst.getConfiguration().getInterfaces());
     assertNotNull(inst.getConfiguration().getPaths());
     assertNotNull(inst.getConfiguration().getSocketBindingGroups());
+  }
+
+  @Test
+  @Transactional
+  @SuppressWarnings("unchecked")
+  void testValidJvmInstancePayload() throws IOException, InterruptedException {
+    clearTables();
+    HttpClient mockClient = mock(HttpClient.class);
+    HttpResponse<byte[]> mockResponse = mock(HttpResponse.class);
+    byte[] buffy = readBytesFromResources("jdk8_MWTELE-66.gz");
+    when(mockClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(mockResponse);
+    when(mockResponse.body()).thenReturn(buffy);
+
+    EventConsumer.setHttpClient(mockClient);
+    String kafkaMessage = readFromResources("incoming_kafka1.json");
+    inMemoryConnector.source(INGRESS_CHANNEL).send(kafkaMessage);
+
+    micrometerAssertionHelper.awaitAndAssertTimerIncrement(CONSUMED_TIMER_NAME, 1);
+    micrometerAssertionHelper.assertCounterIncrement(PROCESSING_EXCEPTION_COUNTER_NAME, 0);
+    assertEquals(1L, jvminstance_count());
+  }
+
+  @Test
+  void testInvalidPayload() throws IOException {
+    inMemoryConnector.source(INGRESS_CHANNEL).send("not a real payload");
+    micrometerAssertionHelper.awaitAndAssertTimerIncrement(CONSUMED_TIMER_NAME, 1);
+    micrometerAssertionHelper.assertCounterIncrement(PROCESSING_EXCEPTION_COUNTER_NAME, 1);
+  }
+
+  @Test
+  @Transactional
+  void testBasicPostgresTransactions() throws IOException {
+    clearTables();
+    ArchiveAnnouncement dummy = new ArchiveAnnouncement();
+    dummy.setAccountId("dummy account id");
+    dummy.setOrgId("dummy org");
+    dummy.setTimestamp(LocalDateTime.now());
+
+    byte[] buffy = readBytesFromResources("jdk8_MWTELE-66.gz");
+    String json = EventConsumer.unzipJson(buffy);
+
+    InsightsMessage msg = jvmInstanceOf(dummy, json);
+    assertTrue(msg instanceof JvmInstance);
+    JvmInstance inst = (JvmInstance) msg;
+
+    assertEquals(0L, jvminstance_count());
+    assertEquals(0L, jarhash_count());
+
+    entityManager.persist(inst);
+    assertEquals(1L, jvminstance_count());
+    assertEquals(1L, jarhash_count());
+
+    entityManager.remove(inst);
+    assertEquals(0L, jvminstance_count());
+    assertEquals(0L, jarhash_count());
+  }
+
+  private void clearTables() {
+    entityManager.createNativeQuery("DELETE FROM jar_hash").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM jvm_instance").executeUpdate();
+  }
+
+  private Long jvminstance_count() {
+    return entityManager
+        .createQuery("SELECT COUNT (*) FROM JvmInstance", Long.class)
+        .getSingleResult();
+  }
+
+  private Long jarhash_count() {
+    return entityManager.createQuery("SELECT COUNT (*) FROM JarHash", Long.class).getSingleResult();
   }
 }

--- a/events/src/test/java/com/redhat/runtimes/inventory/events/MicrometerAssertionHelper.java
+++ b/events/src/test/java/com/redhat/runtimes/inventory/events/MicrometerAssertionHelper.java
@@ -1,0 +1,103 @@
+/* Copyright (C) Red Hat 2023 */
+package com.redhat.runtimes.inventory.events;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * {@link MeterRegistry#clear()} cannot be called between tests to reset counters because it would
+ * remove the counters instances from the registry while we use many {@link ApplicationScoped} beans
+ * which hold references pointing at the aforementioned counters instances. That's why we need this
+ * helper to assert increments in a reliable way.
+ *
+ * <p>This class is based on MicrometerAssertionHelper from RedHatInsights/notifications-backend:
+ * https://github.com/RedHatInsights/notifications-backend/blob/master/common/src/test/java/com/redhat/cloud/notifications/MicrometerAssertionHelper.java
+ */
+@ApplicationScoped
+public class MicrometerAssertionHelper {
+
+  @Inject MeterRegistry registry;
+
+  private final Map<String, Double> counterValuesBeforeTest = new ConcurrentHashMap<>();
+
+  public void saveCounterValuesBeforeTest(String... counterNames) {
+    for (String counterName : counterNames) {
+      counterValuesBeforeTest.put(counterName, registry.counter(counterName).count());
+    }
+  }
+
+  public void assertCounterIncrement(String counterName, double expectedIncrement, String... tags) {
+    double actualIncrement =
+        registry.counter(counterName, tags).count()
+            - counterValuesBeforeTest.getOrDefault(counterName + Arrays.toString(tags), 0D);
+    assertEquals(expectedIncrement, actualIncrement);
+  }
+
+  public void assertNoCounterIncrement(String... counterNames) {
+    for (String counterName : counterNames) {
+      assertCounterIncrement(counterName, 0);
+    }
+  }
+
+  public void awaitAndAssertCounterIncrement(String counterName, double expectedIncrement) {
+    await()
+        .atMost(Duration.ofSeconds(30L))
+        .until(
+            () -> {
+              double actualIncrement =
+                  registry.counter(counterName).count()
+                      - counterValuesBeforeTest.getOrDefault(counterName, 0D);
+              return expectedIncrement == actualIncrement;
+            });
+  }
+
+  public void awaitAndAssertTimerIncrement(String timerName, long expectedIncrement) {
+    await()
+        .atMost(Duration.ofSeconds(30L))
+        .until(
+            () -> {
+              Timer timer = findTimerByNameOnly(timerName);
+              if (timer == null) {
+                // The timer may be created after this method is executed.
+                return false;
+              } else {
+                long actualIncrement = Optional.ofNullable(timer.count()).orElse(0L);
+                return expectedIncrement == actualIncrement;
+              }
+            });
+  }
+
+  public void clearSavedValues() {
+    counterValuesBeforeTest.clear();
+  }
+
+  public void removeDynamicTimer(String timerName) {
+    for (Timer timer : findTimersByNameOnly(timerName)) {
+      registry.remove(timer);
+    }
+  }
+
+  /**
+   * Finds a timer from its name only, tags are ignored. If multiple timers match the name, the
+   * first one will be returned.
+   */
+  private Timer findTimerByNameOnly(String name) {
+    return registry.find(name).timer();
+  }
+
+  /** Finds a collection of timers from their name only, tags are ignored. */
+  private Collection<Timer> findTimersByNameOnly(String name) {
+    return registry.find(name).timers();
+  }
+}

--- a/events/src/test/java/com/redhat/runtimes/inventory/events/TestLifecycleManager.java
+++ b/events/src/test/java/com/redhat/runtimes/inventory/events/TestLifecycleManager.java
@@ -1,0 +1,53 @@
+/* Copyright (C) Red Hat 2023 */
+package com.redhat.runtimes.inventory.events;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * This class is based on TestLifecycleManager from RedHatInsights/notifications-backend:
+ * https://github.com/RedHatInsights/notifications-backend/blob/master/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+ */
+public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager {
+
+  PostgreSQLContainer<?> postgreSQLContainer;
+
+  @Override
+  public Map<String, String> start() {
+    Map<String, String> properties = new HashMap<>();
+    try {
+      setupPostgres(properties);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    /*
+     * We'll use an in-memory Reactive Messaging connector to send payloads.
+     * See https://smallrye.io/smallrye-reactive-messaging/smallrye-reactive-messaging/2/testing/testing.html
+     */
+    properties.putAll(
+        InMemoryConnector.switchIncomingChannelsToInMemory(
+            com.redhat.runtimes.inventory.events.EventConsumer.INGRESS_CHANNEL));
+    return properties;
+  }
+
+  @Override
+  public void stop() {
+    postgreSQLContainer.stop();
+    InMemoryConnector.clear();
+  }
+
+  void setupPostgres(Map<String, String> props) throws SQLException {
+    postgreSQLContainer = new PostgreSQLContainer<>("postgres:14");
+    postgreSQLContainer.start();
+    String jdbcUrl = postgreSQLContainer.getJdbcUrl();
+    props.put("quarkus.datasource.jdbc.url", jdbcUrl);
+    props.put("quarkus.datasource.username", "test");
+    props.put("quarkus.datasource.password", "test");
+    props.put("quarkus.datasource.db-kind", "postgresql");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <jacoco-plugin.version>0.8.9</jacoco-plugin.version>
     <checkstyle.version>10.6.0</checkstyle.version>
 
-    <testcontainers.version>1.17.6</testcontainers.version>
+    <testcontainers.version>1.18.3</testcontainers.version>
     <failsafe.version>3.3.0</failsafe.version>
 
     <mockserver-netty-no-dependencies.version>5.15.0</mockserver-netty-no-dependencies.version>
@@ -55,6 +55,13 @@
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>${quarkus.platform.artifact-id}</artifactId>
         <version>${quarkus.platform.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>${testcontainers.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -144,7 +144,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mockserver</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -156,7 +155,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This PR addresses https://github.com/RedHatInsights/insights-runtimes-inventory/issues/49 [0], in which it'd be nice to have test cases that use TestContainers.

I've enabled the QuarkusTest annotation, and as a base I borrowed some starter code from RedHatInsights/notifications-backend for the TestLifecycleManager [[1]](https://github.com/RedHatInsights/notifications-backend/blob/master/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java) and MicrometerAssertionHelper [[2]](https://github.com/RedHatInsights/notifications-backend/blob/master/common/src/test/java/com/redhat/cloud/notifications/MicrometerAssertionHelper.java).

This PR adds three new unit tests.

- `testBasicPostgresTransactions()` uses a JvmInstance from one of the zipped json test files, and verifies that `entityManager` is able to write it to the postgres database.
- `testValidJvmInstancePayload()` sends a kafka message on the ingress channel, mocks the httpClient to return a valid JvmInstance object, and then verifies that this gets written to the database.
- `testInvalidPayload()` sends gibberish across the ingress channel, and verifies that the exception counter increases.

When trying to run TestContainers initially I was having some troubles because it doesn't seem to be completely friendly to podman, so I had to setup docker. IIRC, podman wasn't able to pull the required container images automatically, so I had to manually pull it and it seemed to be happier. Additionally, if trying this with podman you might need to run something like the following:
```
export DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock
export TESTCONTAINERS_CHECKS_DISABLE=true
export TESTCONTAINERS_RYUK_DISABLED=true
```

Something I'm not sure about and would like some feedback on, is it necessary to create a new HttpClient object for every request, as seen in `getJsonFromS3()` [[3]](https://github.com/aptmac/insights-runtimes-inventory/blob/main/events/src/main/java/com/redhat/runtimes/inventory/events/EventConsumer.java#L462), or can it be re-used? I ask because I needed to mock the HttpClient to sidestep `client.send()`, so I added a package private `setHttpClient()` where I could pass in my mock. It's also been a while since I've used mockito, so if there's a more appropriate way of mocking that client please let me know.

[0] https://github.com/RedHatInsights/insights-runtimes-inventory/issues/49
[1] https://github.com/RedHatInsights/notifications-backend/blob/master/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
[2] https://github.com/RedHatInsights/notifications-backend/blob/master/common/src/test/java/com/redhat/cloud/notifications/MicrometerAssertionHelper.java
[3] https://github.com/aptmac/insights-runtimes-inventory/blob/main/events/src/main/java/com/redhat/runtimes/inventory/events/EventConsumer.java#L462

