### PR TITLE
Change REST path to match route

### DIFF
--- a/rest/src/main/java/com/redhat/runtimes/inventory/web/DisplayInventory.java
+++ b/rest/src/main/java/com/redhat/runtimes/inventory/web/DisplayInventory.java
@@ -17,7 +17,7 @@ import jakarta.ws.rs.core.MediaType;
 import java.util.Base64;
 import java.util.Map;
 
-@Path("/api/runtimes-inventory-service/v1")
+@Path("/api/insights-rbi-rest/v1")
 public class DisplayInventory {
 
   @Inject MeterRegistry registry;


### PR DESCRIPTION
The REST service is set up in Quarkus with the path `/api/runtimes-inventory-service/`, however the OpenShift route for this service uses the path `/api/insights-rbi-rest/`. This means there is no way to query the REST API outside of the Consoledot cluster.

```
$ oc get routes runtimes-inventory-rest-fwtx2 
NAME                            HOST/PORT     PATH                      SERVICES                  PORT   TERMINATION     WILDCARD
runtimes-inventory-rest-fwtx2   example.com   /api/insights-rbi-rest/   runtimes-inventory-rest   auth   edge/Redirect   None
```

This PR changes the Quarkus path to match the OpenShift route.

Querying the route before this PR results in a 404:
```
$ curl -sSf -H "Authorization: Basic $BASIC_AUTH" https://example.com/api/insights-rbi-rest/v1/instance/
curl: (22) The requested URL returned error: 404
```

Querying the path as expected by Quarkus returns the Hybrid Cloud Console home page:
```
$ curl -sSf -H "Authorization: Basic $BASIC_AUTH" https://example.com/api/runtimes-inventory-service/v1/instance/
<!DOCTYPE html>
<html lang="en-US">

<head>
    <meta charset="UTF-8">
    <title>
        Hybrid Cloud Console
    </title>
    <meta http-equiv="Content-Security-Policy" content="default-src 'self' https: wss: data: blob: 'unsafe-inline' 'unsafe-eval' https://*.redhat.com/ https://www.redhat.com  https://*.openshift.com/ https://api.stage.openshift.com/ https://identity.api.openshift.com/ https://www.youtube.com/ https://redhat.sc.omtrdc.net/ https://assets.adobedtm.com https://www.redhat.com https://*.storage.googleapis.com/ https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com https://stage.quay.io https://quay.io;">
    <meta http-equiv="Pragma" content="no-cache">
    <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate">
    <meta http-equiv="x-ua-compatible" content="ie=edge">
    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
    <link rel="icon" type="image/png" href="https://access.redhat.com/webassets/avalon/g/favicon.ico">
    <script type="text/javascript">
        window.insights = {
            chrome: {
                isChrome2: true
            }
        }
    </script>
    <script id="dpal" src="https://www.redhat.com/ma/dpal.js" type="text/javascript"></script>
<base href="/"><link href="/apps/chrome/js/main.b9fe5d78e1ba675b.css" rel="stylesheet"></head>

<body class="pf-m-redhat-font">
    <div id="chrome-entry"></div>
    <div id="consent_blackbar"></div>
<script defer src="/apps/chrome/js/chrome-root.b9fe5d78e1ba675b.js"></script><script defer src="/apps/chrome/js/chrome.b9fe5d78e1ba675b.js"></script></body>
</html>
```

After this PR, you can successfully query the REST API using the route:
```
$ curl -sSf -H "Authorization: Basic $BASIC_AUTH" https://example.com/api/insights-rbi-rest/v1/instance/
{"response": "[not found]"}
```