### PR TITLE
Add unit tests for the rest component

### DIFF
--- a/events/src/main/java/com/redhat/runtimes/inventory/events/EventConsumer.java
+++ b/events/src/main/java/com/redhat/runtimes/inventory/events/EventConsumer.java
@@ -43,12 +43,12 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 
 @ApplicationScoped
 public class EventConsumer {
-  private static final String INGRESS_CHANNEL = "ingress";
-  private static final String REJECTED_COUNTER_NAME = "input.rejected";
-  private static final String PROCESSING_ERROR_COUNTER_NAME = "input.processing.error";
-  private static final String PROCESSING_EXCEPTION_COUNTER_NAME = "input.processing.exception";
-  private static final String DUPLICATE_COUNTER_NAME = "input.duplicate";
-  private static final String CONSUMED_TIMER_NAME = "input.consumed";
+  public static final String INGRESS_CHANNEL = "ingress";
+  public static final String REJECTED_COUNTER_NAME = "input.rejected";
+  public static final String PROCESSING_ERROR_COUNTER_NAME = "input.processing.error";
+  public static final String PROCESSING_EXCEPTION_COUNTER_NAME = "input.processing.exception";
+  public static final String DUPLICATE_COUNTER_NAME = "input.duplicate";
+  public static final String CONSUMED_TIMER_NAME = "input.consumed";
 
   static final String VALID_CONTENT_TYPE =
       "application/vnd.redhat.runtimes-java-general.analytics+tgz";

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -125,6 +125,16 @@
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.groovy</groupId>
+          <artifactId>groovy</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.groovy</groupId>
+          <artifactId>groovy-xml</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>
@@ -147,6 +157,12 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
       <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>runtimes-inventory-events</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/rest/src/test/java/com/redhat/runtimes/inventory/web/DisplayInventoryTest.java
+++ b/rest/src/test/java/com/redhat/runtimes/inventory/web/DisplayInventoryTest.java
@@ -5,10 +5,11 @@ import static com.redhat.runtimes.inventory.models.Constants.X_RH_IDENTITY_HEADE
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.Header;
-import io.vertx.core.json.JsonObject;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import java.io.IOException;
@@ -30,16 +31,21 @@ public class DisplayInventoryTest {
   }
 
   private static String encodeRHIdentityInfo(String accountNumber, String orgId, String username) {
-    JsonObject identity = new JsonObject();
-    JsonObject user = new JsonObject();
+    ObjectMapper mapper = new ObjectMapper();
+
+    ObjectNode user = mapper.createObjectNode();
     user.put("username", username);
+
+    ObjectNode identity = mapper.createObjectNode();
     identity.put("account_number", accountNumber);
     identity.put("org_id", orgId);
-    identity.put("user", user);
+    identity.set("user", user);
     identity.put("type", "User");
-    JsonObject header = new JsonObject();
-    header.put("identity", identity);
-    return encode(header.encode());
+
+    ObjectNode head = mapper.createObjectNode();
+    head.set("identity", identity);
+
+    return encode(head.toString());
   }
 
   @Test

--- a/rest/src/test/java/com/redhat/runtimes/inventory/web/DisplayInventoryTest.java
+++ b/rest/src/test/java/com/redhat/runtimes/inventory/web/DisplayInventoryTest.java
@@ -1,0 +1,70 @@
+/* Copyright (C) Red Hat 2023 */
+package com.redhat.runtimes.inventory.web;
+
+import static com.redhat.runtimes.inventory.models.Constants.X_RH_IDENTITY_HEADER;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.Header;
+import io.vertx.core.json.JsonObject;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import java.io.IOException;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class DisplayInventoryTest {
+
+  @Inject EntityManager entityManager;
+
+  private static Header createRHIdentityHeader(String encodedIdentityHeader) {
+    return new Header(X_RH_IDENTITY_HEADER, encodedIdentityHeader);
+  }
+
+  private static String encode(String value) {
+    return new String(Base64.getEncoder().encode(value.getBytes()));
+  }
+
+  private static String encodeRHIdentityInfo(String accountNumber, String orgId, String username) {
+    JsonObject identity = new JsonObject();
+    JsonObject user = new JsonObject();
+    user.put("username", username);
+    identity.put("account_number", accountNumber);
+    identity.put("org_id", orgId);
+    identity.put("user", user);
+    identity.put("type", "User");
+    JsonObject header = new JsonObject();
+    header.put("identity", identity);
+    return encode(header.encode());
+  }
+
+  @Test
+  public void testInstanceEndpointWithoutValidHeader() {
+    given().when().get("/api/runtimes-inventory-service/v1/instance").then().statusCode(500);
+  }
+
+  @Test
+  public void testInstanceEndpointWithValidHeader() throws IOException {
+    String accountNumber = "accountId";
+    String orgId = "orgId";
+    String username = "user";
+    String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
+    Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    String response =
+        given()
+            .header(identityHeader)
+            .when()
+            .queryParam("hostname", "fedora")
+            .get("/api/runtimes-inventory-service/v1/instance")
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+    assertEquals("{\"response\": \"[not found]\"}", response);
+  }
+}

--- a/rest/src/test/java/com/redhat/runtimes/inventory/web/TestLifecycleManager.java
+++ b/rest/src/test/java/com/redhat/runtimes/inventory/web/TestLifecycleManager.java
@@ -1,6 +1,8 @@
 /* Copyright (C) Red Hat 2023 */
 package com.redhat.runtimes.inventory.web;
 
+import static com.redhat.runtimes.inventory.events.EventConsumer.INGRESS_CHANNEL;
+
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.smallrye.reactive.messaging.memory.InMemoryConnector;
 import java.sql.SQLException;
@@ -14,7 +16,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
  */
 public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager {
 
-  PostgreSQLContainer<?> postgreSQLContainer;
+  private PostgreSQLContainer<?> postgreSQLContainer;
 
   @Override
   public Map<String, String> start() {
@@ -29,9 +31,7 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
      * We'll use an in-memory Reactive Messaging connector to send payloads.
      * See https://smallrye.io/smallrye-reactive-messaging/smallrye-reactive-messaging/2/testing/testing.html
      */
-    properties.putAll(
-        InMemoryConnector.switchIncomingChannelsToInMemory(
-            com.redhat.runtimes.inventory.events.EventConsumer.INGRESS_CHANNEL));
+    properties.putAll(InMemoryConnector.switchIncomingChannelsToInMemory(INGRESS_CHANNEL));
     return properties;
   }
 

--- a/rest/src/test/java/com/redhat/runtimes/inventory/web/TestLifecycleManager.java
+++ b/rest/src/test/java/com/redhat/runtimes/inventory/web/TestLifecycleManager.java
@@ -1,0 +1,53 @@
+/* Copyright (C) Red Hat 2023 */
+package com.redhat.runtimes.inventory.web;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * This class is based on TestLifecycleManager from RedHatInsights/notifications-backend:
+ * https://github.com/RedHatInsights/notifications-backend/blob/master/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+ */
+public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager {
+
+  PostgreSQLContainer<?> postgreSQLContainer;
+
+  @Override
+  public Map<String, String> start() {
+    Map<String, String> properties = new HashMap<>();
+    try {
+      setupPostgres(properties);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    /*
+     * We'll use an in-memory Reactive Messaging connector to send payloads.
+     * See https://smallrye.io/smallrye-reactive-messaging/smallrye-reactive-messaging/2/testing/testing.html
+     */
+    properties.putAll(
+        InMemoryConnector.switchIncomingChannelsToInMemory(
+            com.redhat.runtimes.inventory.events.EventConsumer.INGRESS_CHANNEL));
+    return properties;
+  }
+
+  @Override
+  public void stop() {
+    postgreSQLContainer.stop();
+    InMemoryConnector.clear();
+  }
+
+  void setupPostgres(Map<String, String> props) throws SQLException {
+    postgreSQLContainer = new PostgreSQLContainer<>("postgres:14");
+    postgreSQLContainer.start();
+    String jdbcUrl = postgreSQLContainer.getJdbcUrl();
+    props.put("quarkus.datasource.jdbc.url", jdbcUrl);
+    props.put("quarkus.datasource.username", "test");
+    props.put("quarkus.datasource.password", "test");
+    props.put("quarkus.datasource.db-kind", "postgresql");
+  }
+}


### PR DESCRIPTION
This PR addresses issue: https://github.com/RedHatInsights/insights-runtimes-inventory/issues/63 (and https://github.com/RedHatInsights/insights-runtimes-inventory/issues/49, kind of)

I added a couple of basic unit tests for the rest component, which checks the response code (and response, if successful) of making a request to the `/instance/` endpoint with both a valid and invalid header. It also makes use of the QuarkusTest annotation, so it runs some test containers. I needed to add the events component as a test dependency so that the database would setup properly, otherwise the test was complaining about not having tables. 

