### PR TITLE
Separate unit tests and Quarkus tests into maven profiles

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -173,15 +173,6 @@
         <version>${compiler-plugin.version}</version>
       </plugin>
       <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
-        <configuration>
-          <systemPropertyVariables>
-            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.redhat.insights</groupId>
+    <artifactId>runtimes-inventory</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>runtimes-inventory-coverage</artifactId>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>runtimes-inventory-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>runtimes-inventory-events</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>runtimes-inventory-rest</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>report-aggregate</id>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+            <phase>test</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/events/pom.xml
+++ b/events/pom.xml
@@ -171,15 +171,6 @@
         <version>${compiler-plugin.version}</version>
       </plugin>
       <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
-        <configuration>
-          <systemPropertyVariables>
-            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>

--- a/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerTest.java
+++ b/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerTest.java
@@ -11,14 +11,12 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.runtimes.inventory.models.EapInstance;
 import com.redhat.runtimes.inventory.models.JvmInstance;
-// import io.quarkus.test.junit.QuarkusTest;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Map;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-// @QuarkusTest
 public class EventConsumerTest {
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,112 @@
   </build>
   <profiles>
     <profile>
+      <!-- run only unit tests -->
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${surefire-plugin.version}</version>
+            <configuration>
+              <systemPropertyVariables>
+                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+              </systemPropertyVariables>
+            </configuration>
+            <executions>
+              <execution>
+                <id>default-test</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <!-- exclude integration tests -->
+                  <excludedGroups>integration-tests</excludedGroups>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- run only unit tests + vanilla jacoco -->
       <id>coverage</id>
+      <modules>
+        <module>coverage</module>
+      </modules>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${surefire-plugin.version}</version>
+            <configuration>
+              <systemPropertyVariables>
+                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+              </systemPropertyVariables>
+            </configuration>
+            <executions>
+              <execution>
+                <id>default-test</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <!-- exclude integration tests -->
+                  <excludedGroups>integration-tests</excludedGroups>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>${jacoco-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>default-prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>default-report</id>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+                <phase>test</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- run all tests -->
+      <id>integration</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${surefire-plugin.version}</version>
+            <configuration>
+              <systemPropertyVariables>
+                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- run all tests + quarkus-jacoco -->
+      <id>integration-coverage</id>
+      <modules>
+        <module>coverage</module>
+      </modules>
       <dependencies>
         <dependency>
           <groupId>io.quarkus</groupId>
@@ -148,6 +253,15 @@
       </dependencies>
       <build>
         <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${surefire-plugin.version}</version>
+            <configuration>
+              <systemPropertyVariables>
+                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -182,15 +182,6 @@
         <version>${compiler-plugin.version}</version>
       </plugin>
       <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
-        <configuration>
-          <systemPropertyVariables>
-            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>

--- a/rest/src/test/java/com/redhat/runtimes/inventory/web/DisplayInventoryTest.java
+++ b/rest/src/test/java/com/redhat/runtimes/inventory/web/DisplayInventoryTest.java
@@ -14,10 +14,12 @@ import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import java.io.IOException;
 import java.util.Base64;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
+@Tag("integration-tests")
 public class DisplayInventoryTest {
 
   @Inject EntityManager entityManager;


### PR DESCRIPTION
This PR addresses issue https://github.com/RedHatInsights/insights-runtimes-inventory/issues/65 [0], in which it'd be nice to separate the tests that run testcontainers ("integration tests") from the regular junit tests.

There's a couple issues at the moment with the current test setup. One being that testcontainers could be seen as not a unit test in the traditional sense, as they're more intensive and expensive. Second is that testcontainers doesn't play nicely with all operating systems, so with a team developing on multiple OSs we might want to make these tests opt-in.

The idea with this PR is to tag the test classes that use testcontainers with `integration-test`, and then have extra profiles in the root pom to direct the test flow. The default profile will exclude any test tagged `integration-test`, and the `-P integration` profile will just run everything.

`-P coverage` will still run jacoco on the unit tests, but I've also added `-P integration-coverage` to generate coverage for the testcontainers tests. This is needed because regular junit and QuarkusTests require different jacoco configurations, and unit tests and integration tests require different surefire configurations. 

Regular junit tests will use vanilla jacoco, and I've added a coverage folder that adds a report aggregation step to collate the unit test results.

Using `@QuarkusTest` requires the quarkus-jacoco extension, and this extension only works if at least one `@QuarkusTest` is run [1]. The issue here is that `@QuarkusTest` runs testcontainers, so by our definition of integration tests these test classes need to be separated. 

From a maven profile perspective, we now need a flow of profiles that let us have two different surefire-plugin configurations, each having two different jacoco configurations.

Example usage:
```
mvn clean package // exclude integration tests
mvn clean package -P coverage // exclude integration tests + vanilla jacoco
mvn clean package -P integration // include all tests
mvn clean package -P integration-coverage // include all tests + quarkus-jacoco
```

[0] https://github.com/RedHatInsights/insights-runtimes-inventory/issues/65
[1] https://quarkus.io/guides/tests-with-coverage#coverage-for-tests-not-using-quarkustest