### PR TITLE
Fix typos when setting the attributes of JarHash

### DIFF
--- a/events/src/main/java/com/redhat/runtimes/inventory/events/Utils.java
+++ b/events/src/main/java/com/redhat/runtimes/inventory/events/Utils.java
@@ -124,11 +124,11 @@ final class Utils {
     out.setVersion((String) jarJson.getOrDefault("version", ""));
 
     var attrs = (Map<String, String>) jarJson.getOrDefault("attributes", Map.of());
-    out.setGroupId(attrs.getOrDefault("group_id", ""));
-    out.setVendor(attrs.getOrDefault("vendor", ""));
-    out.setSha1Checksum(attrs.getOrDefault("sha1_checksum", ""));
-    out.setSha256Checksum(attrs.getOrDefault("sha256_checksum", ""));
-    out.setSha512Checksum(attrs.getOrDefault("sha512_checksum", ""));
+    out.setGroupId(attrs.getOrDefault("groupId", ""));
+    out.setVendor(attrs.getOrDefault("Implementation-Vendor", ""));
+    out.setSha1Checksum(attrs.getOrDefault("sha1Checksum", ""));
+    out.setSha256Checksum(attrs.getOrDefault("sha256Checksum", ""));
+    out.setSha512Checksum(attrs.getOrDefault("sha512Checksum", ""));
 
     return out;
   }

--- a/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerTest.java
+++ b/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerTest.java
@@ -10,10 +10,12 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.runtimes.inventory.models.EapInstance;
+import com.redhat.runtimes.inventory.models.JarHash;
 import com.redhat.runtimes.inventory.models.JvmInstance;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -96,5 +98,26 @@ public class EventConsumerTest {
     assertNotNull(inst.getConfiguration().getInterfaces());
     assertNotNull(inst.getConfiguration().getPaths());
     assertNotNull(inst.getConfiguration().getSocketBindingGroups());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testJarHashAttributes() throws IOException {
+    byte[] buffy = readBytesFromResources("jdk8_MWTELE-66.gz");
+    String json = EventConsumer.unzipJson(buffy);
+    ObjectMapper objectMapper = new ObjectMapper();
+    Map<String, Object> map =
+        objectMapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+    Set<JarHash> jarHashes = Utils.jarHashesOf((Map<String, Object>) map.get("jars"));
+    assertEquals(1, jarHashes.size());
+    JarHash jar = jarHashes.iterator().next();
+    assertEquals("JBoss by Red Hat", jar.getVendor());
+    assertEquals("82a8c99551533f4448675f273665cb6d7b750511", jar.getSha1Checksum());
+    assertEquals(
+        "d808a03cf5f844f0d1cf52b340a5c4ad836c052e1288a9b5ac8ca6df6ae9e000",
+        jar.getSha256Checksum());
+    assertEquals(
+        "4c85d6f74cb8a34dca6748873f9b38457c04f253c4b7d1e088010d13eec7021145b338979adf8991f54c2b6241da7d350c2cfac849e603c286aa5fb13edf560f",
+        jar.getSha512Checksum());
   }
 }


### PR DESCRIPTION
I ran into this while testing out retrieval of jar hash information (using the test resource files as input). There are some typos in the attribute names when setting the jar hash information from a jvm instance.

The jar information can look something like:
```
"jars" : [ {
      "name" : "",
      "version" : "",
      "attributes" : {
        "sha1Checksum" : "",
        "Implementation-Vendor" : "",
        "groupId" : "",
        "sha256Checksum" : "",
        "artifactId" : "",
        "sha512Checksum" : "",
        "Implementation-Vendor-Id" : "",
        "version" : ""
      }
} ]
```

And here's an example of what information comes back before & after this commit:

Before:
```
{
  id=ba834aa9-8ebb-4a1b-8ea1-520268a060f2,
  instance=JvmInstance{[..]},
  name='jboss-modules.jar',
  groupId='',
  vendor='',
  version='1.12.0.Final-redhat-00001', 
  sha1Checksum='',
  sha256Checksum='',
  sha512Checksum=''
}
```

After:
```
{
  id=5171a2af-b782-49f6-a59b-88f7f957d6fc,
  instance=JvmInstance{[..]},
  name='jboss-modules.jar',
  groupId='org.jboss.modules',
  vendor='JBoss by Red Hat',
  version='1.12.0.Final-redhat-00001', 
  sha1Checksum='82a8c99551533f4448675f273665cb6d7b750511',
  sha256Checksum='d808a03cf5f844f0d1cf52b340a5c4ad836c052e1288a9b5ac8ca6df6ae9e000',
  sha512Checksum='4c85d6f74cb8a34dca6748873f9b38457c04f253c4b7d1e088010d13eec7021145b338979adf8991f54c2b6241da7d350c2cfac849e603c286aa5fb13edf560f'
}
```