### PR TITLE
Add jvm instance and jar hash endpoints to the rest service

### DIFF
--- a/events/pom.xml
+++ b/events/pom.xml
@@ -215,7 +215,18 @@
           </execution>
         </executions>
       </plugin>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven-jar-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>

--- a/events/src/main/java/com/redhat/runtimes/inventory/events/EventConsumer.java
+++ b/events/src/main/java/com/redhat/runtimes/inventory/events/EventConsumer.java
@@ -198,7 +198,7 @@ public class EventConsumer {
    *                           Utility Methods
    ***************************************************************************/
 
-  static String unzipJson(byte[] buffy) {
+  public static String unzipJson(byte[] buffy) {
     try (var bais = new ByteArrayInputStream(buffy);
         var gunzip = new GZIPInputStream(bais)) {
       return new String(gunzip.readAllBytes());

--- a/events/src/main/java/com/redhat/runtimes/inventory/events/Utils.java
+++ b/events/src/main/java/com/redhat/runtimes/inventory/events/Utils.java
@@ -17,13 +17,13 @@ import io.quarkus.logging.Log;
 import java.time.ZoneOffset;
 import java.util.*;
 
-final class Utils {
+public final class Utils {
   private Utils() {}
 
   /****************************************************************************
    *                             JVM Methods
    ***************************************************************************/
-  static InsightsMessage jvmInstanceOf(ArchiveAnnouncement announce, String json) {
+  public static InsightsMessage jvmInstanceOf(ArchiveAnnouncement announce, String json) {
     var inst = new JvmInstance();
     // Announce fields first
     inst.setAccountId(announce.getAccountId());
@@ -118,7 +118,7 @@ final class Utils {
     return out;
   }
 
-  static JarHash jarHashOf(Map<String, Object> jarJson) {
+  public static JarHash jarHashOf(Map<String, Object> jarJson) {
     var out = new JarHash();
     out.setName((String) jarJson.getOrDefault("name", ""));
     out.setVersion((String) jarJson.getOrDefault("version", ""));

--- a/events/src/test/java/com/redhat/runtimes/inventory/events/TestUtils.java
+++ b/events/src/test/java/com/redhat/runtimes/inventory/events/TestUtils.java
@@ -1,6 +1,7 @@
 /* Copyright (C) Red Hat 2023 */
 package com.redhat.runtimes.inventory.events;
 
+import jakarta.persistence.EntityManager;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,5 +27,39 @@ public final class TestUtils {
       }
       return baos.toByteArray();
     }
+  }
+
+  public static Long entity_count(EntityManager entityManager, String entity) {
+    // I don't know why, but but hibernate throws a ParsingException
+    // when I try a named or positional query parameter
+    return entityManager
+        .createQuery("SELECT COUNT (*) FROM " + entity, Long.class)
+        .getSingleResult();
+  }
+
+  public static Long table_count(EntityManager entityManager, String table) {
+    // I don't know why, but but hibernate throws a ParsingException
+    // when I try a named or positional query parameter
+    return (Long)
+        entityManager
+            .createNativeQuery("SELECT COUNT (*) FROM " + table, Long.class)
+            .getSingleResult();
+  }
+
+  public static void clearTables(EntityManager entityManager) {
+    // Order is important here
+    entityManager.createNativeQuery("DELETE FROM jvm_instance_jar_hash").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM eap_instance_module_jar_hash").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM eap_deployment_archive_jar_hash").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM jar_hash").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM jvm_instance").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM eap_instance").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM eap_configuration").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM eap_configuration_eap_extension").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM eap_configuration_deployments").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM eap_configuration_subsystems").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM eap_deployment").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM eap_extension").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM eap_extension_subsystems").executeUpdate();
   }
 }

--- a/events/src/test/resources/test17.json
+++ b/events/src/test/resources/test17.json
@@ -1,5 +1,6 @@
 {
   "version" : "1.0.0",
+  "idHash" : "e34b58a9a254a1a3b648dd0f3f720fabdce95d2a72681da462e4f6b8a42bc402717c4b3ba4d82eed42c56b4cfe88c8b9034e22f106e7681e2e8a5a808ea8b551",
   "basic" : {
     "app.user.dir" : "/Users/ben/projects/insights4runtimes-spike",
     "java.specification.version" : "17",

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -163,6 +163,13 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>runtimes-inventory-events</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Plugins -->
     <dependency>

--- a/rest/src/main/java/com/redhat/runtimes/inventory/web/DisplayInventory.java
+++ b/rest/src/main/java/com/redhat/runtimes/inventory/web/DisplayInventory.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.redhat.runtimes.inventory.models.JarHash;
 import com.redhat.runtimes.inventory.models.JvmInstance;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -14,10 +15,15 @@ import io.quarkus.logging.Log;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @Path("/api/runtimes-inventory-service/v1")
 public class DisplayInventory {
@@ -34,16 +40,62 @@ public class DisplayInventory {
     processingErrorCounter = registry.counter(PROCESSING_ERROR_COUNTER_NAME);
   }
 
+  /**
+   * Given a RH identity header and a hostname, return all the associated JVM instance IDs
+   *
+   * @param hostname associated with the JVM instance
+   * @param rhIdentity
+   * @return JSON String containing a list of JVM instance IDs
+   */
   @GET
-  @Path("/instance/") // trailing slash is required by api
+  @Path("/instance-ids/") // trailing slash is required by api
   @Produces(MediaType.APPLICATION_JSON)
-  public String getRuntimeRecord(
+  public String getJvmInstanceIdRecords(
       @QueryParam("hostname") String hostname,
       @HeaderParam(X_RH_IDENTITY_HEADER) String rhIdentity) {
     // X_RH header is just B64 encoded - decode for the org ID
-    var rhIdJson = new String(Base64.getDecoder().decode(rhIdentity));
+    String rhIdJson = new String(Base64.getDecoder().decode(rhIdentity));
     Log.debugf("X_RH_IDENTITY_HEADER: %s", rhIdJson);
-    var orgId = "";
+    String orgId = "";
+    try {
+      orgId = extractOrgId(rhIdJson);
+    } catch (Exception e) {
+      processingErrorCounter.increment();
+      return "{\"response\": \"[error]\"}";
+    }
+    // Retrieve from DB
+    TypedQuery<UUID> query =
+        entityManager.createQuery(
+            """
+              SELECT i.id
+              FROM JvmInstance i
+              WHERE i.orgId = :orgId and i.hostname = :hostname
+              ORDER BY i.created desc
+            """,
+            UUID.class);
+    query.setParameter("orgId", orgId);
+    query.setParameter("hostname", hostname);
+    List<UUID> results = query.getResultList();
+    return mapResultListToJson(results);
+  }
+
+  /**
+   * Given a RH identity header and a JVM instance id, return the associated JVM instance
+   *
+   * @param jvmInstanceId id of the JVM instance
+   * @param rhIdentity
+   * @return JSON String containing the specified JVM instance
+   */
+  @GET
+  @Path("/instance/") // trailing slash is required by api
+  @Produces(MediaType.APPLICATION_JSON)
+  public String getJvmInstanceRecord(
+      @QueryParam("jvmInstanceId") String jvmInstanceId,
+      @HeaderParam(X_RH_IDENTITY_HEADER) String rhIdentity) {
+    // X_RH header is just B64 encoded - decode for the org ID
+    String rhIdJson = new String(Base64.getDecoder().decode(rhIdentity));
+    Log.debugf("X_RH_IDENTITY_HEADER: %s", rhIdJson);
+    String orgId = "";
     try {
       orgId = extractOrgId(rhIdJson);
     } catch (Exception e) {
@@ -51,41 +103,185 @@ public class DisplayInventory {
       return """
       {"response": "[error]"}""";
     }
-
     // Retrieve from DB
-    var query =
+    TypedQuery<JvmInstance> query =
         entityManager.createQuery(
             """
-    select new com.redhat.runtimes.inventory.models.JvmInstance(
-      i.id, i.accountId, i.orgId, i.hostname, i.launchTime, i.vendor, i.versionString,
-      i.version, i.majorVersion, i.osArch, i.processors, i.heapMax, i.details, i.created
-    ) from com.redhat.runtimes.inventory.models.JvmInstance i
-    where i.orgId = :orgId and i.hostname = :hostname
-    order by i.created desc""",
+              SELECT new com.redhat.runtimes.inventory.models.JvmInstance(
+                i.id, i.accountId, i.orgId, i.hostname, i.launchTime, i.vendor, i.versionString,
+                i.version, i.majorVersion, i.osArch, i.processors, i.heapMax, i.details, i.created)
+              FROM JvmInstance i
+              WHERE i.orgId = :orgId AND i.id = :id
+              ORDER BY i.created desc
+            """,
             JvmInstance.class);
+    query.setParameter("id", UUID.fromString(jvmInstanceId));
     query.setParameter("orgId", orgId);
-    query.setParameter("hostname", hostname);
-    var results = query.getResultList();
-    Log.debugf("Found %s rows when looking for %s in org %s", results.size(), hostname, orgId);
-    if (results.size() == 0) {
-      return """
-      {"response": "[not found]"}""";
+    JvmInstance result;
+    try {
+      result = query.getSingleResult();
+    } catch (NoResultException e) {
+      return "{\"response\": \"[]\"}";
     }
-
-    var mapper = new ObjectMapper();
+    ObjectMapper mapper = new ObjectMapper();
     mapper.registerModule(new JavaTimeModule());
     try {
-      var map = Map.of("response", results.get(0));
+      Map<String, JvmInstance> map = Map.of("response", result);
       return mapper.writeValueAsString(map);
-
     } catch (JsonProcessingException e) {
       Log.error("JSON Exception", e);
       processingErrorCounter.increment();
-      return """
-      {"response": "[error]"}""";
+      return "{\"response\": \"[error]\"}";
     }
   }
 
+  /**
+   * Given a RH identity header and a hostname, return all the associated JVM instances
+   *
+   * @param hostname associated with the JVM Instance
+   * @param rhIdentity
+   * @return JSON String containing a list of JVM instances
+   */
+  @GET
+  @Path("/instances/")
+  @Produces(MediaType.APPLICATION_JSON)
+  public String getAllJvmInstanceRecords(
+      @QueryParam("hostname") String hostname,
+      @HeaderParam(X_RH_IDENTITY_HEADER) String rhIdentity) {
+    // X_RH header is just B64 encoded - decode for the org ID
+    String rhIdJson = new String(Base64.getDecoder().decode(rhIdentity));
+    Log.debugf("X_RH_IDENTITY_HEADER: %s", rhIdJson);
+    String orgId = "";
+    try {
+      orgId = extractOrgId(rhIdJson);
+    } catch (Exception e) {
+      processingErrorCounter.increment();
+      return "{\"response\": \"[error]\"}";
+    }
+    // Retrieve from DB
+    TypedQuery<JvmInstance> query =
+        entityManager.createQuery(
+            """
+              SELECT new com.redhat.runtimes.inventory.models.JvmInstance(
+                i.id, i.accountId, i.orgId, i.hostname, i.launchTime, i.vendor, i.versionString,
+                i.version, i.majorVersion, i.osArch, i.processors, i.heapMax, i.details, i.created)
+              FROM JvmInstance i
+              WHERE i.orgId = :orgId AND i.hostname = :hostname
+              ORDER BY i.created desc
+            """,
+            JvmInstance.class);
+    query.setParameter("orgId", orgId);
+    query.setParameter("hostname", hostname);
+    List<JvmInstance> results = query.getResultList();
+    return mapResultListToJson(results);
+  }
+
+  /**
+   * Given the id of a JVM instance, return all ids of associated jar hashes
+   *
+   * @param jvmInstanceId identifier of the JVM instance
+   * @return JSON String containing a list of jar hash ids associated with a JVM instance
+   */
+  @GET
+  @Path("/jarhash-ids/")
+  @Produces(MediaType.APPLICATION_JSON)
+  public String getJarHashIdRecords(@QueryParam("jvmInstanceId") String jvmInstanceId) {
+    Query query =
+        entityManager.createNativeQuery(
+            """
+              SELECT j.jar_hash_id
+              FROM jvm_instance_jar_hash j
+              WHERE j.jvm_instance_id = :instanceId
+            """,
+            UUID.class);
+    query.setParameter("instanceId", UUID.fromString(jvmInstanceId));
+    var results = query.getResultList();
+    return mapResultListToJson(results);
+  }
+
+  /**
+   * Given the id of a jar hash, return the associated jar hash
+   *
+   * @param jarHashId identifier of the jar hash
+   * @return JSON String containing the specified jar hash
+   */
+  @GET
+  @Path("/jarhash/")
+  @Produces(MediaType.APPLICATION_JSON)
+  public String getJarHashRecord(@QueryParam("jarHashId") String jarHashId) {
+    TypedQuery<JarHash> query =
+        entityManager.createQuery(
+            """
+              SELECT new com.redhat.runtimes.inventory.models.JarHash(
+                j.id, j.name, j.groupId, j.vendor, j.version,
+                j.sha1Checksum, j.sha256Checksum, j.sha512Checksum)
+              FROM JarHash j
+              WHERE j.id = :jarHashId
+            """,
+            JarHash.class);
+    query.setParameter("jarHashId", UUID.fromString(jarHashId));
+    JarHash result;
+    try {
+      result = query.getSingleResult();
+    } catch (NoResultException e) {
+      return "{\"response\": \"[]\"}";
+    }
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+    try {
+      Map<String, JarHash> map = Map.of("response", result);
+      return mapper.writeValueAsString(map);
+    } catch (JsonProcessingException e) {
+      Log.error("JSON Exception", e);
+      processingErrorCounter.increment();
+      return "{\"response\": \"[error]\"}";
+    }
+  }
+
+  /**
+   * Given a JVM instance identifier, return all associated jar hashes
+   *
+   * @param jvmInstanceId identifier of the JVM instance
+   * @return JSON String containing all jar hashes associated with a particular JVM instance
+   */
+  @GET
+  @Path("/jarhashes/")
+  @Produces(MediaType.APPLICATION_JSON)
+  public String getAllJarHashRecords(@QueryParam("jvmInstanceId") String jvmInstanceId) {
+    Query query =
+        entityManager.createNativeQuery(
+            """
+              SELECT
+                jh.id, jh.name, jh.group_id, jh.vendor, jh.version,
+                jh.sha1Checksum, jh.sha256Checksum, jh.sha512Checksum
+              FROM jvm_instance_jar_hash jt
+              RIGHT JOIN jar_hash jh
+              ON jt.jar_hash_id = jh.id
+              WHERE jt.jvm_instance_id = :instanceId
+            """,
+            JarHash.class);
+    query.setParameter("instanceId", UUID.fromString(jvmInstanceId));
+    var results = query.getResultList();
+    return mapResultListToJson(results);
+  }
+
+  private String mapResultListToJson(List<?> resultList) {
+    if (resultList.size() == 0) {
+      return "{\"response\": \"[]\"}";
+    }
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+    try {
+      Map<String, List<?>> map = Map.of("response", resultList);
+      return mapper.writeValueAsString(map);
+    } catch (JsonProcessingException e) {
+      Log.error("JSON Exception", e);
+      processingErrorCounter.increment();
+      return "{\"response\": \"[error]\"}";
+    }
+  }
+
+  @SuppressWarnings("unchecked")
   static String extractOrgId(String rhIdJson) {
     TypeReference<Map<String, Object>> typeRef = new TypeReference<>() {};
     String out = "";


### PR DESCRIPTION
This PR attempts to address part of issue #48 [[0]](https://github.com/RedHatInsights/insights-runtimes-inventory/issues/48), where the rest service should return more data. Specifically, I've added some extra jvm instance related endpoints, and some for jar hashes.

The current implementation of `/instance/` in `DisplayInventory` retrieves the jvm instances that correspond to a specific orgId and hostname, and returns the first index [[1]](https://github.com/RedHatInsights/insights-runtimes-inventory/blob/main/rest/src/main/java/com/redhat/runtimes/inventory/web/DisplayInventory.java#L78). I've tweaked this so it accepts a jvm instance id and retrieves that singular instance, and added (2) more endpoints:
-  `/instance-ids/` to return all jvm instances matching orgId and hostname
- `/instances/` to return all jvm instances matching orgId and hostname

In the latest update to the data models we no-longer have the jvm instance id as an attribute in the jarhash table, and instead have a `jvm_instance_jar_hash` table that maps jvm instance ids to jar hash ids. I've made these endpoints that work as follows:
- `/jarhash-ids/` to return all jvm instances matching a passed jvm instance id
- `/jarhash/` to return the singular jar hash matching a passed jar hash id
- `/jarhashes/` to return all jarhash matching a passed jvm instance id

I think these cover the basic information retrievals for jvm instances and jar hashes. Let me know if I'm missing anything or if there's anything I've overlooked with this approach.

I've moved some helpful test-related functions into `TestUtils`, and made some of the `Utils` functions public so that they can be used by the rest package. This is also accomplished by using maven-jar-plugin in `/events` to create a test-jar that can be used by `/rest` for the purpose of testing. 

Coverage report for this PR:
![display-inventory-coverage](https://github.com/RedHatInsights/insights-runtimes-inventory/assets/10425301/08ccb589-f718-45aa-bbfc-a786c0ae77d5)

[0] https://github.com/RedHatInsights/insights-runtimes-inventory/issues/48
[1] https://github.com/RedHatInsights/insights-runtimes-inventory/blob/main/rest/src/main/java/com/redhat/runtimes/inventory/web/DisplayInventory.java#L78