### PR TITLE
fix: passing environment to quarkus app as profile

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -48,6 +48,9 @@ objects:
             volumes:
               - emptyDir: {}
                 name: tmpdir
+            env:
+              - name: QUARKUS_PROFILE
+                value: ${ENV_NAME}
           webServices:
             metrics: {}
             private: {}
@@ -88,6 +91,9 @@ objects:
             volumes:
               - emptyDir: {}
                 name: tmpdir
+            env:
+              - name: QUARKUS_PROFILE
+                value: ${ENV_NAME}
           webServices:
             metrics: {}
             private: {}


### PR DESCRIPTION
This will active the profile based on environment name. 

A little caveat is that if I deployed on dev environments, as env name the ephemeral namespace name is passed, where it activates a profile (what does nothing) with the namespace name.