### PR TITLE
Add endpoints to return EapInstance data

### DIFF
--- a/core/src/main/java/com/redhat/runtimes/inventory/models/EapConfiguration.java
+++ b/core/src/main/java/com/redhat/runtimes/inventory/models/EapConfiguration.java
@@ -1,6 +1,7 @@
 /* Copyright (C) Red Hat 2023 */
 package com.redhat.runtimes.inventory.models;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -21,6 +22,7 @@ public final class EapConfiguration {
 
   @OneToOne(fetch = FetchType.LAZY)
   @NaturalId
+  @JsonBackReference
   private EapInstance eapInstance;
 
   @ManyToMany(cascade = CascadeType.PERSIST)

--- a/core/src/main/java/com/redhat/runtimes/inventory/models/EapDeployment.java
+++ b/core/src/main/java/com/redhat/runtimes/inventory/models/EapDeployment.java
@@ -1,6 +1,7 @@
 /* Copyright (C) Red Hat 2023 */
 package com.redhat.runtimes.inventory.models;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -16,6 +17,7 @@ public final class EapDeployment {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @NaturalId
+  @JsonBackReference
   private EapInstance eapInstance;
 
   @NotNull

--- a/core/src/main/java/com/redhat/runtimes/inventory/models/EapInstance.java
+++ b/core/src/main/java/com/redhat/runtimes/inventory/models/EapInstance.java
@@ -1,6 +1,7 @@
 /* Copyright (C) Red Hat 2023 */
 package com.redhat.runtimes.inventory.models;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -36,9 +37,11 @@ public final class EapInstance extends JvmInstance {
       cascade = CascadeType.ALL,
       orphanRemoval = true,
       fetch = FetchType.LAZY)
+  @JsonManagedReference
   private EapConfiguration configuration;
 
   @OneToMany(mappedBy = "eapInstance", cascade = CascadeType.ALL, orphanRemoval = true)
+  @JsonManagedReference
   private Set<EapDeployment> deployments;
 
   /****************************************************************************

--- a/events/src/main/java/com/redhat/runtimes/inventory/events/Utils.java
+++ b/events/src/main/java/com/redhat/runtimes/inventory/events/Utils.java
@@ -154,7 +154,7 @@ public final class Utils {
   /****************************************************************************
    *                             EAP Methods
    ***************************************************************************/
-  static InsightsMessage eapInstanceOf(ArchiveAnnouncement announce, String json) {
+  public static InsightsMessage eapInstanceOf(ArchiveAnnouncement announce, String json) {
     var inst = new EapInstance();
     inst.setRaw(json);
     // Announce fields first

--- a/events/src/main/resources/db/migration/V1.0.0__jvm_instance.sql
+++ b/events/src/main/resources/db/migration/V1.0.0__jvm_instance.sql
@@ -151,15 +151,13 @@ CREATE TABLE public.jvm_instance_jar_hash(
     CONSTRAINT FK_JVM_INSTANCE FOREIGN KEY (jvm_instance_id) REFERENCES jvm_instance (id),
     CONSTRAINT FK_JAR_HASH FOREIGN KEY (jar_hash_id) REFERENCES jar_hash (id)
 );
--- Don't need an eap_instance_jar_hash because it already uses
--- jvm_instance_jar_hash since it is a child class of it
--- CREATE TABLE public.eap_instance_jar_hash(
-    -- eap_instance_id uuid NOT NULL,
-    -- jar_hash_id uuid NOT NULL,
-    -- PRIMARY KEY (eap_instance_id, jar_hash_id),
-    -- CONSTRAINT FK_EAP_INSTANCE FOREIGN KEY (eap_instance_id) REFERENCES eap_instance (id),
-    -- CONSTRAINT FK_JAR_HASH FOREIGN KEY (jar_hash_id) REFERENCES jar_hash (id)
--- );
+CREATE TABLE public.eap_instance_jar_hash(
+    eap_instance_id uuid NOT NULL,
+    jar_hash_id uuid NOT NULL,
+    PRIMARY KEY (eap_instance_id, jar_hash_id),
+    CONSTRAINT FK_EAP_INSTANCE FOREIGN KEY (eap_instance_id) REFERENCES eap_instance (id),
+    CONSTRAINT FK_JAR_HASH FOREIGN KEY (jar_hash_id) REFERENCES jar_hash (id)
+);
 CREATE TABLE public.eap_instance_module_jar_hash(
     eap_instance_id uuid NOT NULL,
     jar_hash_id uuid NOT NULL,

--- a/events/src/test/java/com/redhat/runtimes/inventory/events/TestUtils.java
+++ b/events/src/test/java/com/redhat/runtimes/inventory/events/TestUtils.java
@@ -53,12 +53,12 @@ public final class TestUtils {
     entityManager.createNativeQuery("DELETE FROM eap_deployment_archive_jar_hash").executeUpdate();
     entityManager.createNativeQuery("DELETE FROM jar_hash").executeUpdate();
     entityManager.createNativeQuery("DELETE FROM jvm_instance").executeUpdate();
-    entityManager.createNativeQuery("DELETE FROM eap_instance").executeUpdate();
-    entityManager.createNativeQuery("DELETE FROM eap_configuration").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM eap_deployment").executeUpdate();
     entityManager.createNativeQuery("DELETE FROM eap_configuration_eap_extension").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM eap_configuration").executeUpdate();
+    entityManager.createNativeQuery("DELETE FROM eap_instance").executeUpdate();
     entityManager.createNativeQuery("DELETE FROM eap_configuration_deployments").executeUpdate();
     entityManager.createNativeQuery("DELETE FROM eap_configuration_subsystems").executeUpdate();
-    entityManager.createNativeQuery("DELETE FROM eap_deployment").executeUpdate();
     entityManager.createNativeQuery("DELETE FROM eap_extension").executeUpdate();
     entityManager.createNativeQuery("DELETE FROM eap_extension_subsystems").executeUpdate();
   }

--- a/rest/src/main/java/com/redhat/runtimes/inventory/web/DisplayInventory.java
+++ b/rest/src/main/java/com/redhat/runtimes/inventory/web/DisplayInventory.java
@@ -243,6 +243,7 @@ public class DisplayInventory {
    * Given a RH identity header and a EAP instance id, return the associated EAP instance
    *
    * @param eapInstanceId id of the EAP instance
+   * @param includeRaw determines whether to include the raw json in the response
    * @param rhIdentity
    * @return JSON String containing the specified EAP instance
    */
@@ -251,6 +252,7 @@ public class DisplayInventory {
   @Produces(MediaType.APPLICATION_JSON)
   public String getEapInstanceRecord(
       @QueryParam("eapInstanceId") String eapInstanceId,
+      @QueryParam("includeRaw") String includeRaw,
       @HeaderParam(X_RH_IDENTITY_HEADER) String rhIdentity) {
     // X_RH header is just B64 encoded - decode for the org ID
     String rhIdJson = new String(Base64.getDecoder().decode(rhIdentity));
@@ -277,6 +279,9 @@ public class DisplayInventory {
     EapInstance result;
     try {
       result = query.getSingleResult();
+      if (!Boolean.parseBoolean(includeRaw)) {
+        result.setRaw("");
+      }
     } catch (NoResultException e) {
       return "{\"response\": \"[]\"}";
     }
@@ -296,6 +301,7 @@ public class DisplayInventory {
    * Given a RH identity header and a hostname, return all the associated EAP instances
    *
    * @param hostname associated with the EAP Instance
+   * @param includeRaw determines whether to include the raw json in the response
    * @param rhIdentity
    * @return JSON String containing a list of EAP instances
    */
@@ -304,6 +310,7 @@ public class DisplayInventory {
   @Produces(MediaType.APPLICATION_JSON)
   public String getAllEapInstanceRecords(
       @QueryParam("hostname") String hostname,
+      @QueryParam("includeRaw") String includeRaw,
       @HeaderParam(X_RH_IDENTITY_HEADER) String rhIdentity) {
     // X_RH header is just B64 encoded - decode for the org ID
     String rhIdJson = new String(Base64.getDecoder().decode(rhIdentity));
@@ -328,6 +335,11 @@ public class DisplayInventory {
     query.setParameter("orgId", orgId);
     query.setParameter("hostname", hostname);
     List<EapInstance> results = query.getResultList();
+    if (!Boolean.parseBoolean(includeRaw)) {
+      for (EapInstance result : results) {
+        result.setRaw("");
+      }
+    }
     return mapResultListToJson(results);
   }
 

--- a/rest/src/main/java/com/redhat/runtimes/inventory/web/DisplayInventory.java
+++ b/rest/src/main/java/com/redhat/runtimes/inventory/web/DisplayInventory.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.redhat.runtimes.inventory.models.EapInstance;
 import com.redhat.runtimes.inventory.models.JarHash;
 import com.redhat.runtimes.inventory.models.JvmInstance;
 import io.micrometer.core.instrument.Counter;
@@ -196,6 +197,137 @@ public class DisplayInventory {
             JarHash.class);
     query.setParameter("instanceId", UUID.fromString(jvmInstanceId));
     var results = query.getResultList();
+    return mapResultListToJson(results);
+  }
+
+  /**
+   * Given a RH identity header and a hostname, return all the associated EAP instance IDs
+   *
+   * @param hostname associated with the EAP instance
+   * @param rhIdentity
+   * @return JSON String containing a list of EAP instance IDs
+   */
+  @GET
+  @Path("/eap-instance-ids/") // trailing slash is required by api
+  @Produces(MediaType.APPLICATION_JSON)
+  public String getEapInstanceIdRecords(
+      @QueryParam("hostname") String hostname,
+      @HeaderParam(X_RH_IDENTITY_HEADER) String rhIdentity) {
+    // X_RH header is just B64 encoded - decode for the org ID
+    String rhIdJson = new String(Base64.getDecoder().decode(rhIdentity));
+    Log.debugf("X_RH_IDENTITY_HEADER: %s", rhIdJson);
+    String orgId = "";
+    try {
+      orgId = extractOrgId(rhIdJson);
+    } catch (Exception e) {
+      processingErrorCounter.increment();
+      return "{\"response\": \"[error]\"}";
+    }
+    // Retrieve from DB
+    TypedQuery<UUID> query =
+        entityManager.createQuery(
+            """
+              SELECT i.id
+              FROM EapInstance i
+              WHERE i.orgId = :orgId and i.hostname = :hostname
+              ORDER BY i.created desc
+            """,
+            UUID.class);
+    query.setParameter("orgId", orgId);
+    query.setParameter("hostname", hostname);
+    List<UUID> results = query.getResultList();
+    return mapResultListToJson(results);
+  }
+
+  /**
+   * Given a RH identity header and a EAP instance id, return the associated EAP instance
+   *
+   * @param eapInstanceId id of the EAP instance
+   * @param rhIdentity
+   * @return JSON String containing the specified EAP instance
+   */
+  @GET
+  @Path("/eap-instance/") // trailing slash is required by api
+  @Produces(MediaType.APPLICATION_JSON)
+  public String getEapInstanceRecord(
+      @QueryParam("eapInstanceId") String eapInstanceId,
+      @HeaderParam(X_RH_IDENTITY_HEADER) String rhIdentity) {
+    // X_RH header is just B64 encoded - decode for the org ID
+    String rhIdJson = new String(Base64.getDecoder().decode(rhIdentity));
+    Log.debugf("X_RH_IDENTITY_HEADER: %s", rhIdJson);
+    String orgId = "";
+    try {
+      orgId = extractOrgId(rhIdJson);
+    } catch (Exception e) {
+      processingErrorCounter.increment();
+      return """
+      {"response": "[error]"}""";
+    }
+    // Retrieve from DB
+    TypedQuery<EapInstance> query =
+        entityManager.createQuery(
+            """
+              SELECT i
+              FROM EapInstance i
+              WHERE i.orgId = :orgId AND i.id = :id
+            """,
+            EapInstance.class);
+    query.setParameter("id", UUID.fromString(eapInstanceId));
+    query.setParameter("orgId", orgId);
+    EapInstance result;
+    try {
+      result = query.getSingleResult();
+    } catch (NoResultException e) {
+      return "{\"response\": \"[]\"}";
+    }
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+    try {
+      Map<String, EapInstance> map = Map.of("response", result);
+      return mapper.writeValueAsString(map);
+    } catch (JsonProcessingException e) {
+      Log.error("JSON Exception", e);
+      processingErrorCounter.increment();
+      return "{\"response\": \"[error]\"}";
+    }
+  }
+
+  /**
+   * Given a RH identity header and a hostname, return all the associated EAP instances
+   *
+   * @param hostname associated with the EAP Instance
+   * @param rhIdentity
+   * @return JSON String containing a list of EAP instances
+   */
+  @GET
+  @Path("/eap-instances/")
+  @Produces(MediaType.APPLICATION_JSON)
+  public String getAllEapInstanceRecords(
+      @QueryParam("hostname") String hostname,
+      @HeaderParam(X_RH_IDENTITY_HEADER) String rhIdentity) {
+    // X_RH header is just B64 encoded - decode for the org ID
+    String rhIdJson = new String(Base64.getDecoder().decode(rhIdentity));
+    Log.debugf("X_RH_IDENTITY_HEADER: %s", rhIdJson);
+    String orgId = "";
+    try {
+      orgId = extractOrgId(rhIdJson);
+    } catch (Exception e) {
+      processingErrorCounter.increment();
+      return "{\"response\": \"[error]\"}";
+    }
+    // Retrieve from DB
+    TypedQuery<EapInstance> query =
+        entityManager.createQuery(
+            """
+              SELECT i
+              FROM EapInstance i
+              WHERE i.orgId = :orgId AND i.hostname = :hostname
+              ORDER BY i.created desc
+            """,
+            EapInstance.class);
+    query.setParameter("orgId", orgId);
+    query.setParameter("hostname", hostname);
+    List<EapInstance> results = query.getResultList();
     return mapResultListToJson(results);
   }
 

--- a/rest/src/test/java/com/redhat/runtimes/inventory/web/DisplayInventoryTest.java
+++ b/rest/src/test/java/com/redhat/runtimes/inventory/web/DisplayInventoryTest.java
@@ -15,6 +15,7 @@ import com.redhat.runtimes.inventory.events.ArchiveAnnouncement;
 import com.redhat.runtimes.inventory.events.EventConsumer;
 import com.redhat.runtimes.inventory.events.TestUtils;
 import com.redhat.runtimes.inventory.events.Utils;
+import com.redhat.runtimes.inventory.models.EapInstance;
 import com.redhat.runtimes.inventory.models.InsightsMessage;
 import com.redhat.runtimes.inventory.models.JvmInstance;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -43,6 +44,7 @@ public class DisplayInventoryTest {
   @AfterEach
   @Transactional
   void tearDown() {
+    entityManager.createNativeQuery("DELETE FROM eap_instance_jar_hash").executeUpdate();
     TestUtils.clearTables(entityManager);
   }
 
@@ -97,18 +99,26 @@ public class DisplayInventoryTest {
     return instance;
   }
 
+  private EapInstance getEapInstanceFromJsonFile(String filename) throws IOException {
+    String json = TestUtils.readFromResources(filename);
+    InsightsMessage message = Utils.eapInstanceOf(setupArchiveAnnouncement(), json);
+    assertTrue(message instanceof EapInstance);
+    EapInstance instance = (EapInstance) message;
+    return instance;
+  }
+
   @Transactional
-  void persistJvmInstanceToDatabase(JvmInstance instance) {
+  void persistInstanceToDatabase(Object instance) {
     entityManager.persist(instance);
   }
 
   @Test
-  void testInstanceEndpointWithoutValidHeader() {
+  void testJvmInstanceEndpointWithoutValidHeader() {
     given().when().get("/api/runtimes-inventory-service/v1/instance").then().statusCode(500);
   }
 
   @Test
-  void testInstanceEndpointsWithInvalidGroupId() {
+  void testJvmInstanceEndpointsWithInvalidGroupId() {
     Header identityHeader = createRHIdentityHeader(encode("not-a-real-identity"));
     String[] endpoints = {"instance-ids", "instance", "instances"};
     for (String endpoint : endpoints) {
@@ -128,7 +138,7 @@ public class DisplayInventoryTest {
   }
 
   @Test
-  void testInstanceIdsWithNoJvmInstances() throws IOException {
+  void testJvmInstanceIdsWithNoJvmInstances() throws IOException {
     String accountNumber = "accountId";
     String orgId = "orgId";
     String username = "user";
@@ -149,9 +159,9 @@ public class DisplayInventoryTest {
   }
 
   @Test
-  void testInstanceIdsWithSingleJvmInstance() throws IOException {
+  void testJvmInstanceIdsWithSingleJvmInstance() throws IOException {
     JvmInstance instance = getJvmInstanceFromZipJsonFile("jdk8_MWTELE-66.gz");
-    persistJvmInstanceToDatabase(instance);
+    persistInstanceToDatabase(instance);
     String accountNumber = "accountId";
     String orgId = "orgId";
     String username = "user";
@@ -175,12 +185,12 @@ public class DisplayInventoryTest {
   }
 
   @Test
-  void testInstanceIdsWithMultipleJvmInstances() throws IOException {
-    persistJvmInstanceToDatabase(getJvmInstanceFromZipJsonFile("jdk8_MWTELE-66.gz"));
+  void testJvmInstanceIdsWithMultipleJvmInstances() throws IOException {
+    persistInstanceToDatabase(getJvmInstanceFromZipJsonFile("jdk8_MWTELE-66.gz"));
     JvmInstance modifiedInstance = getJvmInstanceFromJsonFile("test17.json");
     // set the hostname to match the previous instance
     modifiedInstance.setHostname("fedora");
-    persistJvmInstanceToDatabase(modifiedInstance);
+    persistInstanceToDatabase(modifiedInstance);
     assertEquals(2L, TestUtils.entity_count(entityManager, "JvmInstance"));
 
     String accountNumber = "accountId";
@@ -205,23 +215,10 @@ public class DisplayInventoryTest {
     assertEquals(2, jsonNode.size());
   }
 
-  private List<String> mapResponseIdsToList(String response)
-      throws JsonMappingException, JsonProcessingException {
-    ObjectMapper mapper = new ObjectMapper();
-    JsonNode jsonNode = mapper.readTree(response).get("response");
-    List<String> ids = new ArrayList<String>();
-    if (jsonNode.isArray()) {
-      for (JsonNode node : jsonNode) {
-        ids.add(node.asText());
-      }
-    }
-    return ids;
-  }
-
   @Test
-  void testInstanceWithValidId() throws IOException {
+  void testJvmInstanceWithValidId() throws IOException {
     JvmInstance instance = getJvmInstanceFromZipJsonFile("jdk8_MWTELE-66.gz");
-    persistJvmInstanceToDatabase(instance);
+    persistInstanceToDatabase(instance);
     String accountNumber = "accountId";
     String orgId = "orgId";
     String username = "user";
@@ -261,9 +258,9 @@ public class DisplayInventoryTest {
   }
 
   @Test
-  void testInstanceWithInvalidId() throws IOException {
+  void testJvmInstanceWithInvalidId() throws IOException {
     JvmInstance instance = getJvmInstanceFromZipJsonFile("jdk8_MWTELE-66.gz");
-    persistJvmInstanceToDatabase(instance);
+    persistInstanceToDatabase(instance);
     String accountNumber = "accountId";
     String orgId = "orgId";
     String username = "user";
@@ -291,7 +288,7 @@ public class DisplayInventoryTest {
   }
 
   @Test
-  void testInstancesWithNoInstances() {
+  void testJvmInstancesWithNoInstances() {
     String accountNumber = "accountId";
     String orgId = "orgId";
     String username = "user";
@@ -312,12 +309,12 @@ public class DisplayInventoryTest {
   }
 
   @Test
-  void testInstancesWithMultipleJvmInstances() throws IOException {
-    persistJvmInstanceToDatabase(getJvmInstanceFromZipJsonFile("jdk8_MWTELE-66.gz"));
+  void testJvmInstancesWithMultipleJvmInstances() throws IOException {
+    persistInstanceToDatabase(getJvmInstanceFromZipJsonFile("jdk8_MWTELE-66.gz"));
     JvmInstance modifiedInstance = getJvmInstanceFromJsonFile("test17.json");
     // set the hostname to match the previous instance
     modifiedInstance.setHostname("fedora");
-    persistJvmInstanceToDatabase(modifiedInstance);
+    persistInstanceToDatabase(modifiedInstance);
     assertEquals(2L, TestUtils.entity_count(entityManager, "JvmInstance"));
     String accountNumber = "accountId";
     String orgId = "orgId";
@@ -360,7 +357,7 @@ public class DisplayInventoryTest {
   void testJarHashesWithSingleRecord() throws IOException {
     // this jvm instance has 1 jar hash associated with it
     JvmInstance instance = getJvmInstanceFromZipJsonFile("jdk8_MWTELE-66.gz");
-    persistJvmInstanceToDatabase(instance);
+    persistInstanceToDatabase(instance);
     String accountNumber = "accountId";
     String orgId = "orgId";
     String username = "user";
@@ -399,7 +396,7 @@ public class DisplayInventoryTest {
   void testJarHashesWithMultipleRecords() throws IOException {
     // this jvm instance has 11 jar hashes associated with it
     JvmInstance instance = getJvmInstanceFromJsonFile("test17.json");
-    persistJvmInstanceToDatabase(getJvmInstanceFromJsonFile("test17.json"));
+    persistInstanceToDatabase(getJvmInstanceFromJsonFile("test17.json"));
     String accountNumber = "accountId";
     String orgId = "orgId";
     String username = "user";
@@ -432,5 +429,202 @@ public class DisplayInventoryTest {
     JsonNode jsonNode = mapper.readTree(response).get("response");
     assertEquals(true, jsonNode.isArray());
     assertEquals(11, jsonNode.size());
+  }
+
+  @Test
+  void testEapInstanceEndpointsWithInvalidGroupId() {
+    Header identityHeader = createRHIdentityHeader(encode("not-a-real-identity"));
+    String[] endpoints = {"eap-instance-ids", "eap-instance", "eap-instances"};
+    for (String endpoint : endpoints) {
+      String response =
+          given()
+              .header(identityHeader)
+              .when()
+              .queryParam("hostname", "fedora")
+              .get("/api/runtimes-inventory-service/v1/" + endpoint)
+              .then()
+              .statusCode(200)
+              .extract()
+              .body()
+              .asString();
+      assertEquals("{\"response\": \"[error]\"}", response);
+    }
+  }
+
+  @Test
+  void testEapInstanceIdsWithNoEapInstances() throws IOException {
+    String accountNumber = "accountId";
+    String orgId = "orgId";
+    String username = "user";
+    String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
+    Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    String response =
+        given()
+            .header(identityHeader)
+            .when()
+            .queryParam("hostname", "freya")
+            .get("/api/runtimes-inventory-service/v1/eap-instance-ids/")
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+    assertEquals("{\"response\": \"[]\"}", response);
+  }
+
+  @Test
+  void testEapInstanceIdsWithSingleEapInstance() throws IOException {
+    EapInstance instance = getEapInstanceFromJsonFile("eap_example1.json");
+    persistInstanceToDatabase(instance);
+    String accountNumber = "accountId";
+    String orgId = "orgId";
+    String username = "user";
+    String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
+    Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    String response =
+        given()
+            .header(identityHeader)
+            .when()
+            .queryParam("hostname", instance.getHostname())
+            .get("/api/runtimes-inventory-service/v1/eap-instance-ids/")
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode jsonNode = mapper.readTree(response).get("response");
+    assertEquals(true, jsonNode.isArray());
+    assertEquals(1, jsonNode.size());
+  }
+
+  @Test
+  void testEapInstanceWithValidId() throws IOException {
+    EapInstance instance = getEapInstanceFromJsonFile("eap_example1.json");
+    persistInstanceToDatabase(instance);
+    String accountNumber = "accountId";
+    String orgId = "orgId";
+    String username = "user";
+    String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
+    Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    String response =
+        given()
+            .header(identityHeader)
+            .when()
+            .queryParam("hostname", instance.getHostname())
+            .get("/api/runtimes-inventory-service/v1/eap-instance-ids/")
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+    List<String> ids = mapResponseIdsToList(response);
+    assertEquals(1, ids.size());
+    String secondResponse =
+        given()
+            .header(identityHeader)
+            .when()
+            .queryParam("eapInstanceId", ids.get(0))
+            .get("/api/runtimes-inventory-service/v1/eap-instance/")
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode responseNode = mapper.readTree(secondResponse).get("response");
+    assertEquals(instance.getId(), UUID.fromString(responseNode.get("id").asText()));
+    assertEquals(instance.getEapVersion(), responseNode.get("eapVersion").asText());
+    assertEquals(instance.getEapXp(), responseNode.get("eapXp").asBoolean());
+  }
+
+  @Test
+  void testEapInstanceWithInvalidId() throws IOException {
+    EapInstance instance = getEapInstanceFromJsonFile("eap_example1.json");
+    persistInstanceToDatabase(instance);
+    String accountNumber = "accountId";
+    String orgId = "orgId";
+    String username = "user";
+    String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
+    Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    given()
+        .header(identityHeader)
+        .when()
+        .queryParam("hostname", instance.getHostname())
+        .get("/api/runtimes-inventory-service/v1/eap-instance-ids/")
+        .then()
+        .statusCode(200);
+    String response =
+        given()
+            .header(identityHeader)
+            .when()
+            .queryParam("eapInstanceId", UUID.randomUUID().toString())
+            .get("/api/runtimes-inventory-service/v1/eap-instance/")
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+    assertEquals("{\"response\": \"[]\"}", response);
+  }
+
+  @Test
+  void testEapInstancesWithNoInstances() {
+    String accountNumber = "accountId";
+    String orgId = "orgId";
+    String username = "user";
+    String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
+    Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    String response =
+        given()
+            .header(identityHeader)
+            .when()
+            .queryParam("hostname", "fedora")
+            .get("/api/runtimes-inventory-service/v1/eap-instances/")
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+    assertEquals("{\"response\": \"[]\"}", response);
+  }
+
+  @Test
+  void testEapInstances() throws IOException {
+    EapInstance instance = getEapInstanceFromJsonFile("eap_example1.json");
+    persistInstanceToDatabase(instance);
+    String accountNumber = "accountId";
+    String orgId = "orgId";
+    String username = "user";
+    String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
+    Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    String response =
+        given()
+            .header(identityHeader)
+            .when()
+            .queryParam("hostname", instance.getHostname())
+            .get("/api/runtimes-inventory-service/v1/eap-instances/")
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode jsonNode = mapper.readTree(response).get("response");
+    assertEquals(true, jsonNode.isArray());
+    assertEquals(1, jsonNode.size());
+  }
+
+  private List<String> mapResponseIdsToList(String response)
+      throws JsonMappingException, JsonProcessingException {
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode jsonNode = mapper.readTree(response).get("response");
+    List<String> ids = new ArrayList<String>();
+    if (jsonNode.isArray()) {
+      for (JsonNode node : jsonNode) {
+        ids.add(node.asText());
+      }
+    }
+    return ids;
   }
 }


### PR DESCRIPTION
This PR addresses issue #48 [[0]](https://github.com/RedHatInsights/insights-runtimes-inventory/issues/48), in which it'd be nice to be able to retrieve EapInstance data from the db.

With the recent commits to shuffle around EapInstance and JvmInstance shared fields, the response from a single EapInstance is much smaller. To further shrink this, I've added a query param `includeRaw` that gets cast to a boolean, to control whether or not to return the raw json field.

Example curl commands (tested on localhost):
```
curl -X GET http://127.0.0.1:9087/api/runtimes-inventory-service/v1/eap-instances/\?hostname=freya -H "x-rh-identity:$IDENTITY"

curl -X GET http://127.0.0.1:9087/api/runtimes-inventory-service/v1/eap-instances/\?hostname=freya&includeRaw=false -H "x-rh-identity:$IDENTITY"
```

The structure of the endpoints are similar to the JvmInstance ones I made before. There's `/eap-instances/` that returns all the instances of a given hostname, and then `/eap-instance-ids/` which can be used with `/eap-instance/` to return a single eap instance. This should give us some general endpoints to use for testing/initial work, at least until the ui designs are in a state where we can start forming endpoints to serve that specific data.

I wrote about a few other findings I had made last week in the issue [[1]](https://github.com/RedHatInsights/insights-runtimes-inventory/issues/48#issuecomment-1730217649), but for ease of reading I'll paste them again here:

- the eap_instance_jar_hash table is indeed necessary for the retrieval of eap instance data, hibernate complains about a missing relation otherwise
- I had to add some @JsonManagedReference and @JsonBackReference between EapInstance and both EapDeployments and EapConfiguration, otherwise there's infinite recursion when retrieving info
- in the tests, I tried using eap-connect1.json and eap-connect2.json to populate the db with, but they have a different format from eap_example1.json (which looks to be our point of truth at the moment). Are the first two jsons valid eap instances?

Coverage report:
![Screenshot from 2023-09-26 15-56-57](https://github.com/RedHatInsights/insights-runtimes-inventory/assets/10425301/e4ba728f-7ade-443e-919f-cebc4fc45ae9)

[0] https://github.com/RedHatInsights/insights-runtimes-inventory/issues/48
[1] https://github.com/RedHatInsights/insights-runtimes-inventory/issues/48#issuecomment-1730217649