### PR TITLE
Update Cloudwatch configuration

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -51,6 +51,8 @@ objects:
             env:
               - name: QUARKUS_PROFILE
                 value: ${ENV_NAME}
+              - name: QUARKUS_LOG_CLOUDWATCH_ENABLED
+                value: ${CLOUDWATCH_ENABLED}
           webServices:
             metrics: {}
             private: {}
@@ -94,6 +96,8 @@ objects:
             env:
               - name: QUARKUS_PROFILE
                 value: ${ENV_NAME}
+              - name: QUARKUS_LOG_CLOUDWATCH_ENABLED
+                value: ${CLOUDWATCH_ENABLED}
           webServices:
             metrics: {}
             private: {}
@@ -121,3 +125,6 @@ parameters:
   - name: ENV_NAME
     required: true
     value: stage
+  - name: CLOUDWATCH_ENABLED
+    value: "false"
+    displayName: Enable Cloudwatch logging

--- a/events/src/main/resources/application.properties
+++ b/events/src/main/resources/application.properties
@@ -78,7 +78,7 @@ quarkus.qute.property-not-found-strategy=throw-exception
 
 quarkus.log.level=INFO
 quarkus.log.cloudwatch.enabled=false
-quarkus.log.cloudwatch.log-stream-name=runtimes-inventory
+quarkus.log.cloudwatch.log-stream-name=insights-rbi-events
 quarkus.log.cloudwatch.level=INFO
 # These properties are overriden by Clowder config
 quarkus.log.cloudwatch.region=placeholder

--- a/events/src/main/resources/application.properties
+++ b/events/src/main/resources/application.properties
@@ -78,10 +78,11 @@ quarkus.qute.property-not-found-strategy=throw-exception
 
 quarkus.log.level=INFO
 quarkus.log.cloudwatch.enabled=false
-quarkus.log.cloudwatch.region=us-east-1
-quarkus.log.cloudwatch.log-group=notificationsLogGroup
-quarkus.log.cloudwatch.log-stream-name=notifications-backend
+quarkus.log.cloudwatch.log-stream-name=runtimes-inventory
 quarkus.log.cloudwatch.level=INFO
+# These properties are overriden by Clowder config
+quarkus.log.cloudwatch.region=placeholder
+quarkus.log.cloudwatch.log-group=placeholder
 quarkus.log.cloudwatch.access-key-id=placeholder
 quarkus.log.cloudwatch.access-key-secret=placeholder
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <clowder-quarkus-config-source.version>1.3.0</clowder-quarkus-config-source.version>
 
-    <quarkus-logging-cloudwatch.version>6.1.0</quarkus-logging-cloudwatch.version>
+    <quarkus-logging-cloudwatch.version>6.3.0</quarkus-logging-cloudwatch.version>
     <quarkus-logging-sentry.version>1.2.1</quarkus-logging-sentry.version>
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/rest/src/main/resources/application.properties
+++ b/rest/src/main/resources/application.properties
@@ -46,10 +46,11 @@ quarkus.qute.property-not-found-strategy=throw-exception
 
 quarkus.log.level=INFO
 quarkus.log.cloudwatch.enabled=false
-quarkus.log.cloudwatch.region=us-east-1
-quarkus.log.cloudwatch.log-group=notificationsLogGroup
-quarkus.log.cloudwatch.log-stream-name=notifications-backend
+quarkus.log.cloudwatch.log-stream-name=runtimes-inventory
 quarkus.log.cloudwatch.level=INFO
+# These properties are overriden by Clowder config
+quarkus.log.cloudwatch.region=placeholder
+quarkus.log.cloudwatch.log-group=placeholder
 quarkus.log.cloudwatch.access-key-id=placeholder
 quarkus.log.cloudwatch.access-key-secret=placeholder
 

--- a/rest/src/main/resources/application.properties
+++ b/rest/src/main/resources/application.properties
@@ -46,7 +46,7 @@ quarkus.qute.property-not-found-strategy=throw-exception
 
 quarkus.log.level=INFO
 quarkus.log.cloudwatch.enabled=false
-quarkus.log.cloudwatch.log-stream-name=runtimes-inventory
+quarkus.log.cloudwatch.log-stream-name=insights-rbi-rest
 quarkus.log.cloudwatch.level=INFO
 # These properties are overriden by Clowder config
 quarkus.log.cloudwatch.region=placeholder


### PR DESCRIPTION
This PR adds a `CLOUDWATCH_ENABLED` template parameter which controls whether Cloudwatch is enabled using the quarkus-logging-cloudwatch extension (which I've upgraded). I fixed some properties in application.properties to better show which properties are overridden by Clowder using the clowder-quarkus-config-source extension. I also changed the log stream name so we can distinguish logs between the rest and events pods.