### PR TITLE
Add mock RBAC server for integration tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -276,7 +276,18 @@
           </execution>
         </executions>
       </plugin>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven-jar-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/core/src/test/java/com/redhat/runtimes/inventory/MockServerConfig.java
+++ b/core/src/test/java/com/redhat/runtimes/inventory/MockServerConfig.java
@@ -1,0 +1,65 @@
+/* Copyright (C) Red Hat 2023 */
+package com.redhat.runtimes.inventory;
+
+import static com.redhat.runtimes.inventory.models.Constants.X_RH_IDENTITY_HEADER;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import java.io.InputStream;
+import org.apache.commons.io.IOUtils;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.ClearType;
+
+public class MockServerConfig {
+
+  public enum RbacAccess {
+    FULL_ACCESS(getFileAsString("rbac-examples/rbac_example_full_access.json")),
+    INVENTORY_READ_ACCESS_ONLY(
+        getFileAsString("rbac-examples/rbac_example_events_inventory_read_access_only.json")),
+    HOSTS_ACCESS_ONLY(getFileAsString("rbac-examples/rbac_example_events_hosts_access_only.json")),
+    READ_ACCESS(getFileAsString("rbac-examples/rbac_example_read_access.json")),
+    NO_ACCESS(getFileAsString("rbac-examples/rbac_example_no_access.json"));
+
+    private final String payload;
+
+    RbacAccess(String payload) {
+      this.payload = payload;
+    }
+
+    public String getPayload() {
+      return payload;
+    }
+  }
+
+  public static void addMockRbacAccess(
+      ClientAndServer client, String xRhIdentity, RbacAccess access) {
+    client
+        .when(
+            request()
+                .withPath("/api/rbac/v1/access/")
+                .withQueryStringParameter("application", "inventory")
+                .withHeader(X_RH_IDENTITY_HEADER, xRhIdentity))
+        .respond(
+            response()
+                .withStatusCode(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(access.getPayload()));
+  }
+
+  public static void clearRbac(ClientAndServer client) {
+    client.clear(request().withPath("/api/rbac/v1/access/"), ClearType.EXPECTATIONS);
+  }
+
+  private static String getFileAsString(String filename) {
+    System.out.println("MOCKSERVERCONFIG: " + MockServerConfig.class.getResource("/"));
+    try (InputStream is = MockServerConfig.class.getClassLoader().getResourceAsStream(filename)) {
+      return IOUtils.toString(is, UTF_8);
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail("Failed to read RBAC example file: " + filename, e);
+      return "";
+    }
+  }
+}

--- a/core/src/test/java/com/redhat/runtimes/inventory/MockServerConfig.java
+++ b/core/src/test/java/com/redhat/runtimes/inventory/MockServerConfig.java
@@ -12,6 +12,7 @@ import org.apache.commons.io.IOUtils;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.ClearType;
 
+// Derived from notifications-backend
 public class MockServerConfig {
 
   public enum RbacAccess {
@@ -53,7 +54,6 @@ public class MockServerConfig {
   }
 
   private static String getFileAsString(String filename) {
-    System.out.println("MOCKSERVERCONFIG: " + MockServerConfig.class.getResource("/"));
     try (InputStream is = MockServerConfig.class.getClassLoader().getResourceAsStream(filename)) {
       return IOUtils.toString(is, UTF_8);
     } catch (Exception e) {

--- a/core/src/test/resources/rbac-examples/rbac_example_read_access.json
+++ b/core/src/test/resources/rbac-examples/rbac_example_read_access.json
@@ -1,0 +1,19 @@
+{
+  "meta": {
+    "count": 10,
+    "limit": 25,
+    "offset": 0
+  },
+  "links": {
+    "first": "/api/rbac/v1/access/?application=%2A&limit=10&offset=0",
+    "next": null,
+    "previous": null,
+    "last": "/api/rbac/v1/access/?application=%2A&limit=10&offset=0"
+  },
+  "data": [
+    {
+      "permission": "inventory:*:read",
+      "resourceDefinitions": []
+    }
+  ]
+}

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -170,6 +170,13 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>runtimes-inventory-core</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Plugins -->
     <dependency>

--- a/rest/src/test/java/com/redhat/runtimes/inventory/web/DisplayInventoryTest.java
+++ b/rest/src/test/java/com/redhat/runtimes/inventory/web/DisplayInventoryTest.java
@@ -119,7 +119,7 @@ public class DisplayInventoryTest {
 
   @Test
   void testJvmInstanceEndpointWithoutValidHeader() {
-    given().when().get("/api/runtimes-inventory-service/v1/instance").then().statusCode(500);
+    given().when().get("/api/runtimes-inventory-service/v1/instance").then().statusCode(401);
   }
 
   @Test
@@ -129,18 +129,13 @@ public class DisplayInventoryTest {
     MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String[] endpoints = {"instance-ids", "instance", "instances"};
     for (String endpoint : endpoints) {
-      String response =
-          given()
-              .header(identityHeader)
-              .when()
-              .queryParam("hostname", "fedora")
-              .get("/api/runtimes-inventory-service/v1/" + endpoint)
-              .then()
-              .statusCode(200)
-              .extract()
-              .body()
-              .asString();
-      assertEquals("{\"response\": \"[error]\"}", response);
+      given()
+          .header(identityHeader)
+          .when()
+          .queryParam("hostname", "fedora")
+          .get("/api/runtimes-inventory-service/v1/" + endpoint)
+          .then()
+          .statusCode(401);
     }
   }
 
@@ -354,10 +349,15 @@ public class DisplayInventoryTest {
 
   @Test
   void testJarHashesWithNoRecords() throws IOException {
-    String identityHeaderValue = encode("not-a-real-identity");
+    String accountNumber = "accountId";
+    String orgId = "orgId";
+    String username = "user";
+    String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
+    Header identityHeader = createRHIdentityHeader(identityHeaderValue);
     MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
+            .header(identityHeader)
             .when()
             .queryParam("jvmInstanceId", UUID.randomUUID().toString())
             .get("/api/runtimes-inventory-service/v1/jarhashes/")
@@ -395,6 +395,7 @@ public class DisplayInventoryTest {
     assertEquals(1, ids.size());
     String response =
         given()
+            .header(identityHeader)
             .when()
             .queryParam("jvmInstanceId", UUID.fromString(ids.get(0)))
             .get("/api/runtimes-inventory-service/v1/jarhashes/")
@@ -435,6 +436,7 @@ public class DisplayInventoryTest {
     assertEquals(1, ids.size());
     String response =
         given()
+            .header(identityHeader)
             .when()
             .queryParam("jvmInstanceId", UUID.fromString(ids.get(0)))
             .get("/api/runtimes-inventory-service/v1/jarhashes/")
@@ -456,18 +458,13 @@ public class DisplayInventoryTest {
     MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String[] endpoints = {"eap-instance-ids", "eap-instance", "eap-instances"};
     for (String endpoint : endpoints) {
-      String response =
-          given()
-              .header(identityHeader)
-              .when()
-              .queryParam("hostname", "fedora")
-              .get("/api/runtimes-inventory-service/v1/" + endpoint)
-              .then()
-              .statusCode(200)
-              .extract()
-              .body()
-              .asString();
-      assertEquals("{\"response\": \"[error]\"}", response);
+      given()
+          .header(identityHeader)
+          .when()
+          .queryParam("hostname", "fedora")
+          .get("/api/runtimes-inventory-service/v1/" + endpoint)
+          .then()
+          .statusCode(401);
     }
   }
 

--- a/rest/src/test/java/com/redhat/runtimes/inventory/web/DisplayInventoryTest.java
+++ b/rest/src/test/java/com/redhat/runtimes/inventory/web/DisplayInventoryTest.java
@@ -1,7 +1,9 @@
 /* Copyright (C) Red Hat 2023 */
 package com.redhat.runtimes.inventory.web;
 
+import static com.redhat.runtimes.inventory.MockServerConfig.RbacAccess.FULL_ACCESS;
 import static com.redhat.runtimes.inventory.models.Constants.X_RH_IDENTITY_HEADER;
+import static com.redhat.runtimes.inventory.web.MockServerLifecycleManager.getClient;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -12,6 +14,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.redhat.runtimes.inventory.MockServerConfig;
 import com.redhat.runtimes.inventory.events.ArchiveAnnouncement;
 import com.redhat.runtimes.inventory.events.EventConsumer;
 import com.redhat.runtimes.inventory.events.TestUtils;
@@ -47,6 +50,7 @@ public class DisplayInventoryTest {
   void tearDown() {
     entityManager.createNativeQuery("DELETE FROM eap_instance_jar_hash").executeUpdate();
     TestUtils.clearTables(entityManager);
+    MockServerConfig.clearRbac(getClient());
   }
 
   private static Header createRHIdentityHeader(String encodedIdentityHeader) {
@@ -120,7 +124,9 @@ public class DisplayInventoryTest {
 
   @Test
   void testJvmInstanceEndpointsWithInvalidGroupId() {
-    Header identityHeader = createRHIdentityHeader(encode("not-a-real-identity"));
+    String identityHeaderValue = encode("not-a-real-identity");
+    Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String[] endpoints = {"instance-ids", "instance", "instances"};
     for (String endpoint : endpoints) {
       String response =
@@ -145,6 +151,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
             .header(identityHeader)
@@ -168,6 +175,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
             .header(identityHeader)
@@ -199,6 +207,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
             .header(identityHeader)
@@ -225,6 +234,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
             .header(identityHeader)
@@ -267,6 +277,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     given()
         .header(identityHeader)
         .when()
@@ -295,6 +306,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
             .header(identityHeader)
@@ -322,6 +334,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
             .header(identityHeader)
@@ -341,6 +354,8 @@ public class DisplayInventoryTest {
 
   @Test
   void testJarHashesWithNoRecords() throws IOException {
+    String identityHeaderValue = encode("not-a-real-identity");
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
             .when()
@@ -364,6 +379,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String jvmInstanceIdsResponse =
         given()
             .header(identityHeader)
@@ -403,6 +419,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String jvmInstanceIdsResponse =
         given()
             .header(identityHeader)
@@ -434,7 +451,9 @@ public class DisplayInventoryTest {
 
   @Test
   void testEapInstanceEndpointsWithInvalidGroupId() {
-    Header identityHeader = createRHIdentityHeader(encode("not-a-real-identity"));
+    String identityHeaderValue = encode("not-a-real-identity");
+    Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String[] endpoints = {"eap-instance-ids", "eap-instance", "eap-instances"};
     for (String endpoint : endpoints) {
       String response =
@@ -459,6 +478,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
             .header(identityHeader)
@@ -482,6 +502,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
             .header(identityHeader)
@@ -508,6 +529,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
             .header(identityHeader)
@@ -549,6 +571,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
             .header(identityHeader)
@@ -590,6 +613,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
             .header(identityHeader)
@@ -631,6 +655,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     given()
         .header(identityHeader)
         .when()
@@ -659,6 +684,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
             .header(identityHeader)
@@ -682,6 +708,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
             .header(identityHeader)
@@ -709,6 +736,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
             .header(identityHeader)
@@ -737,6 +765,7 @@ public class DisplayInventoryTest {
     String username = "user";
     String identityHeaderValue = encodeRHIdentityInfo(accountNumber, orgId, username);
     Header identityHeader = createRHIdentityHeader(identityHeaderValue);
+    MockServerConfig.addMockRbacAccess(getClient(), identityHeaderValue, FULL_ACCESS);
     String response =
         given()
             .header(identityHeader)

--- a/rest/src/test/java/com/redhat/runtimes/inventory/web/MockServerLifecycleManager.java
+++ b/rest/src/test/java/com/redhat/runtimes/inventory/web/MockServerLifecycleManager.java
@@ -5,6 +5,7 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
 import org.mockserver.integration.ClientAndServer;
 
+// Derived from notifications-backend
 public class MockServerLifecycleManager {
 
   private static final String LOG_LEVEL_KEY = "mockserver.logLevel";

--- a/rest/src/test/java/com/redhat/runtimes/inventory/web/MockServerLifecycleManager.java
+++ b/rest/src/test/java/com/redhat/runtimes/inventory/web/MockServerLifecycleManager.java
@@ -1,0 +1,40 @@
+/* Copyright (C) Red Hat 2023 */
+package com.redhat.runtimes.inventory.web;
+
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+
+import org.mockserver.integration.ClientAndServer;
+
+public class MockServerLifecycleManager {
+
+  private static final String LOG_LEVEL_KEY = "mockserver.logLevel";
+
+  private static ClientAndServer mockServer;
+  private static String mockServerUrl;
+
+  public static void start() {
+    if (System.getProperty(LOG_LEVEL_KEY) == null) {
+      System.setProperty(LOG_LEVEL_KEY, "OFF");
+      System.out.println(
+          "MockServer log is disabled. Use '-D"
+              + LOG_LEVEL_KEY
+              + "=WARN|INFO|DEBUG|TRACE' to enable it.");
+    }
+    mockServer = startClientAndServer();
+    mockServerUrl = "http://localhost:" + mockServer.getPort();
+  }
+
+  public static String getMockServerUrl() {
+    return mockServerUrl;
+  }
+
+  public static ClientAndServer getClient() {
+    return mockServer;
+  }
+
+  public static void stop() {
+    if (mockServer != null) {
+      mockServer.stop();
+    }
+  }
+}

--- a/rest/src/test/java/com/redhat/runtimes/inventory/web/TestLifecycleManager.java
+++ b/rest/src/test/java/com/redhat/runtimes/inventory/web/TestLifecycleManager.java
@@ -3,6 +3,7 @@ package com.redhat.runtimes.inventory.web;
 
 import static com.redhat.runtimes.inventory.events.EventConsumer.EGG_CHANNEL;
 import static com.redhat.runtimes.inventory.events.EventConsumer.INGRESS_CHANNEL;
+import static com.redhat.runtimes.inventory.web.MockServerLifecycleManager.getMockServerUrl;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.smallrye.reactive.messaging.memory.InMemoryConnector;
@@ -27,6 +28,7 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+    setupMockEngine(properties);
 
     /*
      * We'll use an in-memory Reactive Messaging connector to send payloads.
@@ -51,5 +53,10 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
     props.put("quarkus.datasource.username", "test");
     props.put("quarkus.datasource.password", "test");
     props.put("quarkus.datasource.db-kind", "postgresql");
+  }
+
+  void setupMockEngine(Map<String, String> props) {
+    MockServerLifecycleManager.start();
+    props.put("quarkus.rest-client.rbac-authentication.url", getMockServerUrl());
   }
 }


### PR DESCRIPTION
This PR fixes the integration tests by adding a mock RBAC server derived from https://github.com/RedHatInsights/notifications-backend/commit/7daece1490a0b344ed9bda43047f88e95e65dff5.