### PR TITLE
Use maven-failsafe-plugin for integration tests

### DIFF
--- a/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerIT.java
+++ b/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerIT.java
@@ -34,13 +34,11 @@ import java.time.Instant;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-@Tag("integration-tests")
-public class EventConsumerIntegrationTest {
+public class EventConsumerIT {
 
   @Inject EntityManager entityManager;
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,8 @@
 
     <google-java-format.version>1.15.0</google-java-format.version>
     <spotless-maven-plugin.version>2.29.0</spotless-maven-plugin.version>
-    <surefire-plugin.version>3.0.0-M8</surefire-plugin.version>
+    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <failsafe-plugin.version>${surefire-plugin.version}</failsafe-plugin.version>
     <checkstyle-plugin.version>3.2.1</checkstyle-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <jacoco-plugin.version>0.8.9</jacoco-plugin.version>
@@ -161,6 +162,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${failsafe-plugin.version}</version>
         <configuration>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/pom.xml
+++ b/pom.xml
@@ -141,113 +141,46 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire-plugin.version}</version>
+        <configuration>
+          <systemPropertyVariables>
+            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+          </systemPropertyVariables>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+            <quarkus.jacoco.reuse-data-file>true</quarkus.jacoco.reuse-data-file>
+          </systemPropertyVariables>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>
     <profile>
-      <!-- run only unit tests -->
-      <id>default</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
-            <configuration>
-              <systemPropertyVariables>
-                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-              </systemPropertyVariables>
-            </configuration>
-            <executions>
-              <execution>
-                <id>default-test</id>
-                <goals>
-                  <goal>test</goal>
-                </goals>
-                <configuration>
-                  <!-- exclude integration tests -->
-                  <excludedGroups>integration-tests</excludedGroups>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <!-- run only unit tests + vanilla jacoco -->
       <id>coverage</id>
-      <modules>
-        <module>coverage</module>
-      </modules>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
-            <configuration>
-              <systemPropertyVariables>
-                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-              </systemPropertyVariables>
-            </configuration>
-            <executions>
-              <execution>
-                <id>default-test</id>
-                <goals>
-                  <goal>test</goal>
-                </goals>
-                <configuration>
-                  <!-- exclude integration tests -->
-                  <excludedGroups>integration-tests</excludedGroups>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <version>${jacoco-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>default-prepare-agent</id>
-                <goals>
-                  <goal>prepare-agent</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>default-report</id>
-                <goals>
-                  <goal>report</goal>
-                </goals>
-                <phase>test</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <!-- run all tests -->
-      <id>integration</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
-            <configuration>
-              <systemPropertyVariables>
-                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-              </systemPropertyVariables>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <!-- run all tests + quarkus-jacoco -->
-      <id>integration-coverage</id>
       <modules>
         <module>coverage</module>
       </modules>
@@ -260,15 +193,6 @@
       </dependencies>
       <build>
         <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
-            <configuration>
-              <systemPropertyVariables>
-                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-              </systemPropertyVariables>
-            </configuration>
-          </plugin>
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>

--- a/rest/src/test/java/com/redhat/runtimes/inventory/web/ConsoleIdentityProviderIT.java
+++ b/rest/src/test/java/com/redhat/runtimes/inventory/web/ConsoleIdentityProviderIT.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 
 /** Test ConsoleIdentityProvider. Brought over from notifications-backend and extended */
 @QuarkusTest
-public class ConsoleIdentityProviderTest {
+public class ConsoleIdentityProviderIT {
 
   @Test
   void testNullOrgId() {

--- a/rest/src/test/java/com/redhat/runtimes/inventory/web/DisplayInventoryIT.java
+++ b/rest/src/test/java/com/redhat/runtimes/inventory/web/DisplayInventoryIT.java
@@ -35,13 +35,11 @@ import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-@Tag("integration-tests")
-public class DisplayInventoryTest {
+public class DisplayInventoryIT {
 
   @Inject EntityManager entityManager;
 


### PR DESCRIPTION
This PR addresses issue https://github.com/RedHatInsights/insights-runtimes-inventory/issues/123 [[0]](https://github.com/RedHatInsights/insights-runtimes-inventory/issues/123), in which maven-failsafe-plugin should be used for handling the integration tests.

The changes are pretty straightforward, I renamed some of the QuarkusTests to be `*IT.java`, and removed the tag annotations for integration-test now that they aren't needed. The quarkus-jacoco plugin looks to be working even on the unit tests now which is nice, so we can just have the one profile for coverage: `-P coverage`.

How it worked before:
`mvn clean package`
`mvn clean package -P coverage`
`mvn clean package -P integration`
`mvn clean package -P integration-coverage`

How it works now:
`mvn clean package`
`mvn clean package -P coverage`
`mvn clean verify`
`mvn clean verify -P coverage`


