### PR TITLE
Set JAVA_OPT -XX:MaxRAMPercentage for events container to 80%

### DIFF
--- a/deploy/docker/events/Dockerfile
+++ b/deploy/docker/events/Dockerfile
@@ -26,7 +26,7 @@ RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
     && chown 1001:root /deployments \
     && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
-ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Dquarkus.http.port=8000 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+ExitOnOutOfMemoryError"
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Dquarkus.http.port=8000 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+ExitOnOutOfMemoryError -XX:MaxRAMPercentage=80"
 
 # Use four distinct layers so if there are application changes the library layers can be re-used
 COPY --from=build --chown=1001 /home/jboss/events/target/quarkus-app/lib/ /deployments/lib/


### PR DESCRIPTION
By default Java seems to set `MaxRAMPercentage` to 25%, meaning the events container will run out of memory when it hits 500 MB of the 2 GB given to it.

This change sets it to 80%.