### PR TITLE
Increase events memory limit to 20GB

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -44,7 +44,7 @@ objects:
             resources:
               limits:
                 cpu: 500m
-                memory: 2Gi
+                memory: 20Gi
               requests:
                 cpu: 150m
                 memory: 1Gi

--- a/deploy/docker/events/Dockerfile
+++ b/deploy/docker/events/Dockerfile
@@ -26,7 +26,7 @@ RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
     && chown 1001:root /deployments \
     && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
-ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Dquarkus.http.port=8000 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+ExitOnOutOfMemoryError -XX:MaxRAMPercentage=80 -XX:+PrintFlagsFinal"
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Dquarkus.http.port=8000 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:-ExitOnOutOfMemoryError -XX:MaxRAMPercentage=80 -XX:+PrintFlagsFinal"
 
 # Use four distinct layers so if there are application changes the library layers can be re-used
 COPY --from=build --chown=1001 /home/jboss/events/target/quarkus-app/lib/ /deployments/lib/

--- a/deploy/docker/events/Dockerfile
+++ b/deploy/docker/events/Dockerfile
@@ -26,7 +26,7 @@ RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
     && chown 1001:root /deployments \
     && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
-ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Dquarkus.http.port=8000 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+ExitOnOutOfMemoryError -XX:MaxRAMPercentage=80"
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Dquarkus.http.port=8000 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+ExitOnOutOfMemoryError -XX:MaxRAMPercentage=80 -XX:+PrintFlagsFinal"
 
 # Use four distinct layers so if there are application changes the library layers can be re-used
 COPY --from=build --chown=1001 /home/jboss/events/target/quarkus-app/lib/ /deployments/lib/


### PR DESCRIPTION
Increases the events container memory limit to 20GB. With 80% MaxRAMPercentage, this should give us 16GB max for the heap. Print the JVM flags to verify this.

Don't exit on OutOfMemoryError