### PR TITLE
Revert sql comment that breaks previous file checksum.

### DIFF
--- a/events/src/main/resources/db/migration/V1.0.0__jvm_instance.sql
+++ b/events/src/main/resources/db/migration/V1.0.0__jvm_instance.sql
@@ -1,5 +1,3 @@
--- noinspection SqlNoDataSourceInspectionForFile
-
 CREATE TABLE public.jvm_instance(
     id uuid NOT NULL,
     linking_hash character varying(255) NOT NULL,


### PR DESCRIPTION
The change, while innocuous, causes flyway to fail checksum comparisons, which causes it to reject the script.