### PR TITLE
Use fixed tags for Cryostat images

### DIFF
--- a/deploy/cryostat.yml
+++ b/deploy/cryostat.yml
@@ -222,7 +222,7 @@ objects:
               capabilities:
                 drop:
                   - ALL
-            image: registry.redhat.io/cryostat-tech-preview/cryostat-grafana-dashboard-rhel8:${CRYOSTAT_IMAGE_TAG}
+            image: registry.redhat.io/cryostat-tech-preview/cryostat-grafana-dashboard-rhel8:${CRYOSTAT_GRAFANA_IMAGE_TAG}
             imagePullPolicy: IfNotPresent
             env:
               - name: JFR_DATASOURCE_URL
@@ -244,7 +244,7 @@ objects:
               capabilities:
                 drop:
                   - ALL
-            image: registry.redhat.io/cryostat-tech-preview/jfr-datasource-rhel8:${CRYOSTAT_IMAGE_TAG}
+            image: registry.redhat.io/cryostat-tech-preview/jfr-datasource-rhel8:${JFR_DATASOURCE_IMAGE_TAG}
             imagePullPolicy: IfNotPresent
             env:
               - name: LISTEN_HOST
@@ -310,5 +310,11 @@ parameters:
     value: ""
     displayName: Grafana Route Host
   - name: CRYOSTAT_IMAGE_TAG
-    value: 2.3.1
-    displayName: The Cryostat image tag to deploy
+    value: 2.3.1-10
+    displayName: The main Cryostat image tag to deploy
+  - name: JFR_DATASOURCE_IMAGE_TAG
+    value: 2.3.1-10
+    displayName: The JFR Data Source image tag to deploy
+  - name: CRYOSTAT_GRAFANA_IMAGE_TAG
+    value: 2.3.1-10
+    displayName: The main Cryostat Grafana dashboard image tag to deploy


### PR DESCRIPTION
Use fixed tags instead of floating tags for Cryostat images to hopefully satisfy app-interface CI. While these are currently all the same for each component, that's not guaranteed. 