### PR TITLE
Add rh-registry-pull secret to Cryostat ServiceAccount

### DIFF
--- a/deploy/cryostat.yml
+++ b/deploy/cryostat.yml
@@ -11,6 +11,8 @@ objects:
       app.kubernetes.io/name: cryostat
       app.kubernetes.io/instance: cryostat
       app.kubernetes.io/version: "2.3.1.redhat"
+  imagePullSecrets:
+    - name: rh-registry-pull
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:


### PR DESCRIPTION
This pull secret allows image pulls from registry.redhat.io. The secret should be present on all environments.