### PR TITLE
Remove namespace from Cryostat subject

### DIFF
--- a/deploy/cryostat.yml
+++ b/deploy/cryostat.yml
@@ -67,7 +67,6 @@ objects:
   subjects:
     - kind: ServiceAccount
       name: cryostat
-      namespace: default
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
The `default` namespace here is incorrect. It seems like Kubernetes defaults to the RoleBinding's namespace if none is provided. The API docs don't seem to mention this, but this Kubernetes code seems to indicate it:
https://github.com/kubernetes/kubernetes/blob/246d363ea4bab2ac99a938d0cee73d72fc44de45/pkg/registry/rbac/validation/rule.go#L289-L295

I tested the change in an Ephemeral Environment and it seems to work.