### PR TITLE
Add fabriciorby/maven-surefire-junit5-tree-reporter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <spotless-maven-plugin.version>2.29.0</spotless-maven-plugin.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <failsafe-plugin.version>${surefire-plugin.version}</failsafe-plugin.version>
+    <surefire-tree-reporter.version>1.2.1</surefire-tree-reporter.version>
     <checkstyle-plugin.version>3.2.1</checkstyle-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <jacoco-plugin.version>0.8.9</jacoco-plugin.version>
@@ -149,7 +150,29 @@
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
           </systemPropertyVariables>
+          <!-- config for maven-surefire-junit5-tree-reporter -->
+          <reportFormat>plain</reportFormat>
+          <consoleOutputReporter>
+            <disable>true</disable>
+          </consoleOutputReporter>
+          <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
+            <printStacktraceOnError>true</printStacktraceOnError>
+            <printStacktraceOnFailure>true</printStacktraceOnFailure>
+            <printStdoutOnError>true</printStdoutOnError>
+            <printStdoutOnFailure>true</printStdoutOnFailure>
+            <printStdoutOnSuccess>false</printStdoutOnSuccess>
+            <printStderrOnError>true</printStderrOnError>
+            <printStderrOnFailure>true</printStderrOnFailure>
+            <printStderrOnSuccess>false</printStderrOnSuccess>
+          </statelessTestsetInfoReporter>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>me.fabriciorby</groupId>
+            <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+            <version>${surefire-tree-reporter.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>default-test</id>
@@ -168,7 +191,17 @@
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <quarkus.jacoco.reuse-data-file>true</quarkus.jacoco.reuse-data-file>
           </systemPropertyVariables>
+          <!-- config for maven-surefire-junit5-tree-reporter -->
+          <reportFormat>plain</reportFormat>
+          <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"></statelessTestsetInfoReporter>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>me.fabriciorby</groupId>
+            <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+            <version>${surefire-tree-reporter.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
This PR adds the maven-surefire-junit5-tree-reporter extension, which was formerly tracked by #118.

The plugin adds a nice tree view to the test results for improved readability.

The default setting of `<consoleOutputReporter><disable>true</disable></consoleOutputReporter>` to disables console output, and then is followed up by using settings to show output/stacktraces on test errors and failures.

For the integration tests I opted not to go with the default settings, because of how useful the logs are from hibernate/quarkus/testcontainers in addition to the stacktrace.

Example:
Unit tests:
![unit-tests-okay](https://github.com/RedHatInsights/insights-runtimes-inventory/assets/10425301/f6fa8933-bb39-4532-88d9-3ca05b3e6c6f) 

Integration tests:
![integration-tests](https://github.com/RedHatInsights/insights-runtimes-inventory/assets/10425301/c1a033fa-1314-4c21-a2b0-9dc041100524)
