### PR TITLE
Fix processing egg headers.

### DIFF
--- a/events/src/main/java/com/redhat/runtimes/inventory/events/ArchiveAnnouncement.java
+++ b/events/src/main/java/com/redhat/runtimes/inventory/events/ArchiveAnnouncement.java
@@ -41,6 +41,9 @@ public class ArchiveAnnouncement {
   @JsonProperty("platform_metadata")
   private Map<String, Object> platformMetadata;
 
+  @JsonProperty("host")
+  private Map<String, Object> host;
+
   public ArchiveAnnouncement() {}
 
   // For egg uploads, we identify them via the is_runtimes field in the platform_metadata
@@ -63,6 +66,32 @@ public class ArchiveAnnouncement {
   @JsonProperty("url")
   public void setUrl(String url) {
     this.url = url;
+  }
+
+  @JsonProperty("org_id")
+  public String getOrgId() {
+    if (host == null) {
+      return this.orgId;
+    }
+    return String.valueOf(host.get("org_id"));
+  }
+
+  @JsonProperty("org_id")
+  public void setOrgId(String orgId) {
+    this.orgId = orgId;
+  }
+
+  @JsonProperty("account")
+  public String getAccountId() {
+    if (host == null) {
+      return this.accountId;
+    }
+    return String.valueOf(host.get("account"));
+  }
+
+  @JsonProperty("account")
+  public void setAccountId(String accountId) {
+    this.accountId = accountId;
   }
 
   ////////////////////////////////////////////////////////////////////////
@@ -97,26 +126,6 @@ public class ArchiveAnnouncement {
     this.timestamp = timestamp;
   }
 
-  @JsonProperty("account")
-  public String getAccountId() {
-    return this.accountId;
-  }
-
-  @JsonProperty("account")
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  @JsonProperty("org_id")
-  public String getOrgId() {
-    return this.orgId;
-  }
-
-  @JsonProperty("org_id")
-  public void setOrgId(String orgId) {
-    this.orgId = orgId;
-  }
-
   @JsonProperty("request_id")
   public String getRequestId() {
     return requestId;
@@ -145,5 +154,15 @@ public class ArchiveAnnouncement {
   @JsonProperty("platform_metadata")
   public void setPlatformMetadata(Map<String, Object> platformMetadata) {
     this.platformMetadata = platformMetadata;
+  }
+
+  @JsonProperty("host")
+  public Map<String, Object> getHost() {
+    return host;
+  }
+
+  @JsonProperty("host")
+  public void setHost(Map<String, Object> host) {
+    this.host = host;
   }
 }

--- a/events/src/test/resources/egg_is_runtimes.json
+++ b/events/src/test/resources/egg_is_runtimes.json
@@ -1,15 +1,63 @@
 {
   "type": "updated",
-  "org_id": "16790890",
-  "account": "11487129",
-  "content_type": "application/vnd.redhat.runtimes-java-general.analytics+tgz",
-  "request_id": "3f339044-4acb-4972-96e9-cb9c14ec4b45",
+  "host": {
+    "id": "aa6d366c-d2ca-472f-9710-cc7d9a757515",
+    "display_name": "physical_pzkxnvlg.example.info",
+    "ansible_host": null,
+    "account": "11487129",
+    "org_id": "16790890",
+    "insights_id": "0e5ede78-1d82-47c8-a0b2-34bbad6aa875",
+    "subscription_manager_id": "526a7a76-4621-473d-94f9-5d0bc5d4dd19",
+    "satellite_id": null,
+    "fqdn": "physical_pzkxnvlg.example.info",
+    "bios_uuid": "a76d4afe-77d1-4795-93d4-0568e8cf2dcd",
+    "ip_addresses": null,
+    "mac_addresses": null,
+    "facts": [
+      {
+        "namespace": "rhsm",
+        "facts": {
+          "orgId": "16790890",
+          "MEMORY": 1,
+          "RH_PROD": [
+            "69"
+          ],
+          "IS_VIRTUAL": false,
+          "ARCHITECTURE": "x86_64",
+          "SYNC_TIMESTAMP": "2023-08-30T07:35:59.62347389Z"
+        }
+      }
+    ],
+    "provider_id": null,
+    "provider_type": null,
+    "created": "2023-08-30T06:47:40.980983+00:00",
+    "updated": "2023-08-30T07:35:59.670568+00:00",
+    "stale_timestamp": "2023-09-01T07:35:59.623473+00:00",
+    "stale_warning_timestamp": "2023-09-08T07:35:59.623473+00:00",
+    "culled_timestamp": "2023-09-15T07:35:59.623473+00:00",
+    "reporter": "rhsm-conduit",
+    "tags": [],
+    "system_profile": {
+      "arch": "x86_64",
+      "owner_id": "526a7a76-4621-473d-94f9-5d0bc5d4dd19",
+      "cores_per_socket": 1,
+      "number_of_sockets": 1,
+      "infrastructure_type": "physical",
+      "system_memory_bytes": 14336
+    },
+    "per_reporter_staleness": {
+      "rhsm-conduit": {
+        "last_check_in": "2023-08-30T07:35:59.670324+00:00",
+        "stale_timestamp": "2023-09-01T07:35:59.623473+00:00",
+        "check_in_succeeded": true
+      }
+    },
+    "groups": []
+  },
   "timestamp": "2023-08-30T07:35:59.678761+00:00",
   "platform_metadata": {
-    "org_id": "1234567",
     "request_id": "3f339044-4acb-4972-96e9-cb9c14ec4b45",
-    "is_runtimes": true,
-    "url": "http://env-ephemeral-tklsfv-minio.ephemeral-tklsfv.svc:9000/insights-upload-perma/ingress-service-7cd6ffb567-js5fn/1J6DOEu9ni-000029?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=jPyVrodwpcNG%2F20230201%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230201T113343Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=b40f454a4854fe2e673f9a7fb5385949465efe73eb018fb33ecdc1024fb6c06f"
+    "is_runtimes": true
   },
   "metadata": {
     "request_id": "3f339044-4acb-4972-96e9-cb9c14ec4b45"

--- a/events/src/test/resources/egg_is_runtimes.json
+++ b/events/src/test/resources/egg_is_runtimes.json
@@ -57,7 +57,8 @@
   "timestamp": "2023-08-30T07:35:59.678761+00:00",
   "platform_metadata": {
     "request_id": "3f339044-4acb-4972-96e9-cb9c14ec4b45",
-    "is_runtimes": true
+    "is_runtimes": true,
+    "url": "http://env-ephemeral-tklsfv-minio.ephemeral-tklsfv.svc:9000/insights-upload-perma/ingress-service-7cd6ffb567-js5fn/1J6DOEu9ni-000029?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=jPyVrodwpcNG%2F20230201%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230201T113343Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=b40f454a4854fe2e673f9a7fb5385949465efe73eb018fb33ecdc1024fb6c06f"
   },
   "metadata": {
     "request_id": "3f339044-4acb-4972-96e9-cb9c14ec4b45"


### PR DESCRIPTION
This changes the ArchiveAnnouncement object to look inside the host property of egg headers for various necessary fields.

I also reverted some changes I had (incorrectly) made to the example egg header file used for tests.

I did add back a url field into it which was missing. This would have to exist to have seen the errors we were seeing in TEST/PROD, so that seems correct.