### PR TITLE
Increase CPU resources, use G1 GC

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -43,10 +43,10 @@ objects:
               timeoutSeconds: 120
             resources:
               limits:
-                cpu: 500m
+                cpu: "4"
                 memory: 20Gi
               requests:
-                cpu: 150m
+                cpu: "2"
                 memory: 1Gi
             volumeMounts:
               - mountPath: /tmp
@@ -94,7 +94,13 @@ objects:
               periodSeconds: 5
               successThreshold: 1
               timeoutSeconds: 120
-            resources: {}
+            resources:
+              limits:
+                cpu: 300m
+                memory: 1Gi
+              requests:
+                cpu: 150m
+                memory: 512Mi
             volumeMounts:
               - mountPath: /tmp
                 name: tmpdir

--- a/deploy/docker/events/Dockerfile
+++ b/deploy/docker/events/Dockerfile
@@ -23,6 +23,7 @@ COPY --from=build --chown=185 /home/jboss/events/target/quarkus-app/quarkus/ /de
 # Add a custom run-env.sh script to append any Cryostat system properties
 COPY --from=build --chown=185 /home/jboss/deploy/docker/common/cryostat-run-env.sh /deployments/run-env.sh
 
+ENV GC_CONTAINER_OPTIONS="-XX:+UseG1GC"
 ENV JAVA_OPTS_APPEND="-XX:-ExitOnOutOfMemoryError -Dquarkus.http.host=0.0.0.0 -Dquarkus.http.port=8000 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+PrintFlagsFinal"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 


### PR DESCRIPTION
* Make sure we get >=2 CPUs for the rbi-events pods
* Use the G1 Garbage Collector instead of the Parallel default
* Add explicit resource requests/limits for the rbi-rest pods using existing defaults from prod