### PR TITLE
Sanitize data before persistence

### DIFF
--- a/core/src/main/java/com/redhat/runtimes/inventory/models/InsightsMessage.java
+++ b/core/src/main/java/com/redhat/runtimes/inventory/models/InsightsMessage.java
@@ -1,4 +1,109 @@
 /* Copyright (C) Red Hat 2023 */
 package com.redhat.runtimes.inventory.models;
 
-public sealed interface InsightsMessage permits JvmInstance, UpdateInstance {}
+import java.util.ArrayList;
+
+public sealed interface InsightsMessage permits JvmInstance, UpdateInstance {
+
+  // This will sanitize the message by redacting any sensitive information that we don't want to
+  // persist
+  void sanitize();
+
+  // This will sanitize strings that contain java style parameters
+  // of the type -Dxxxxx=yyyyy by substituting the yyyyy part.
+  static String sanitizeJavaParameters(String parameters) {
+    StringBuilder out = new StringBuilder();
+    String redacted = "=*****"; // What to replace sanitized content with
+
+    for (String token : tokenizeComplexJavaParameters(parameters)) {
+      // We only care about -Dxxxxx=yyyyy params
+      if (token.startsWith("-D") && token.contains("=")) {
+        String[] parts = token.split("=", 2);
+        out.append(parts[0]);
+        out.append(redacted);
+        // We might be parsing json
+        // if so, preserve the list comma or list closing bracket
+        if (token.endsWith(",")) {
+          out.append(',');
+        }
+        if (token.endsWith("]")) {
+          out.append(']');
+        }
+      } else {
+        out.append(token);
+      }
+      out.append(" ");
+    }
+    // Remove the last added space
+    out.deleteCharAt(out.length() - 1);
+    return out.toString();
+  }
+
+  // This tokenizes a string, but with some special rules
+  // It tokenizes based on spaces, but it will interpret quotes
+  // that start in the middle of a string, after an '='
+  // This is important because some of the data we want to preserve might
+  // look like -Dxxxxx="this is all one token"
+  // This is also aware of escape sequences
+  static String[] tokenizeComplexJavaParameters(String parameters) {
+    ArrayList<String> tokens = new ArrayList<String>();
+    StringBuilder word = new StringBuilder();
+    Character currentQuote = null;
+    boolean escaping = false;
+    boolean afterEquals = false;
+    // Order is important here. Rearrange at your own risk.
+    for (char c : parameters.toCharArray()) {
+      // If we're not escaping, start escaping and continue
+      if (c == '\\' && !escaping) {
+        escaping = true;
+        word.append(c);
+        continue;
+      }
+
+      // If we're escaping, always just add to the word and continue
+      if (escaping) {
+        escaping = false;
+        word.append(c);
+        continue;
+      }
+
+      // If we see an '=', remember that and continue
+      if (c == '=') {
+        afterEquals = true;
+        word.append(c);
+        continue;
+      }
+
+      // If we're not in a quote and we hit a space, save the word and continue
+      if (currentQuote == null && c == ' ') {
+        tokens.add(word.toString());
+        word = new StringBuilder();
+        continue;
+      }
+
+      // If we see a quote...
+      if (c == '\'' || c == '"') {
+        // If we are quoting...
+        if (currentQuote != null) {
+          // stop quoting if we're at the matching quote
+          if (c == currentQuote) {
+            currentQuote = null;
+          }
+        } else {
+          // So we're not quoting...
+          // If we're at a new word or after an equals, start quoting
+          if (afterEquals || word.isEmpty()) {
+            currentQuote = c;
+          }
+        }
+      }
+
+      // Otherwise, just add the char
+      afterEquals = false;
+      word.append(c);
+    }
+    // Add the last word for the end of string
+    tokens.add(word.toString());
+    return tokens.toArray(new String[0]);
+  }
+}

--- a/core/src/main/java/com/redhat/runtimes/inventory/models/InsightsMessage.java
+++ b/core/src/main/java/com/redhat/runtimes/inventory/models/InsightsMessage.java
@@ -9,6 +9,8 @@ public sealed interface InsightsMessage permits JvmInstance, UpdateInstance {
   // persist
   void sanitize();
 
+  String REDACTED_VALUE = "ZZZZZZZZZ";
+
   /**
    * Sanitizes a string that contains java style parameters of the type -Dxxxxx=yyyyy by
    * substituting the yyyyy value for an obfuscated string

--- a/core/src/main/java/com/redhat/runtimes/inventory/models/InsightsMessage.java
+++ b/core/src/main/java/com/redhat/runtimes/inventory/models/InsightsMessage.java
@@ -9,7 +9,7 @@ public sealed interface InsightsMessage permits JvmInstance, UpdateInstance {
   // persist
   void sanitize();
 
-  String REDACTED_VALUE = "ZZZZZZZZZ";
+  String REDACTED_VALUE = "=ZZZZZZZZZ";
 
   /**
    * Sanitizes a string that contains java style parameters of the type -Dxxxxx=yyyyy by
@@ -20,14 +20,13 @@ public sealed interface InsightsMessage permits JvmInstance, UpdateInstance {
    */
   static String sanitizeJavaParameters(final String parameters) {
     final StringBuilder out = new StringBuilder();
-    String redacted = "=*****"; // What to replace sanitized content with
 
     for (final String token : tokenizeComplexJavaParameters(parameters)) {
       // We only care about -Dxxxxx=yyyyy params
       if (token.startsWith("-D") && token.contains("=")) {
         String[] parts = token.split("=", 2);
         out.append(parts[0]);
-        out.append(redacted);
+        out.append(REDACTED_VALUE);
         // We might be parsing json
         // if so, preserve the list comma or list closing bracket
         if (token.endsWith(",")) {

--- a/core/src/main/java/com/redhat/runtimes/inventory/models/JvmInstance.java
+++ b/core/src/main/java/com/redhat/runtimes/inventory/models/JvmInstance.java
@@ -597,4 +597,10 @@ public non-sealed class JvmInstance implements InsightsMessage {
     sb.append('}');
     return sb.toString();
   }
+
+  @Override
+  public void sanitize() {
+    setJvmArgs(InsightsMessage.sanitizeJavaParameters(getJvmArgs()));
+    setJavaCommand(InsightsMessage.sanitizeJavaParameters(getJavaCommand()));
+  }
 }

--- a/core/src/main/java/com/redhat/runtimes/inventory/models/UpdateInstance.java
+++ b/core/src/main/java/com/redhat/runtimes/inventory/models/UpdateInstance.java
@@ -19,4 +19,9 @@ public final class UpdateInstance implements InsightsMessage {
   public List<JarHash> getUpdates() {
     return updates;
   }
+
+  @Override
+  public void sanitize() {
+    // No-op
+  }
 }

--- a/core/src/test/java/com/redhat/runtimes/inventory/models/InsightsMessageTest.java
+++ b/core/src/test/java/com/redhat/runtimes/inventory/models/InsightsMessageTest.java
@@ -1,6 +1,7 @@
 /* Copyright (C) Red Hat 2023 */
 package com.redhat.runtimes.inventory.models;
 
+import static com.redhat.runtimes.inventory.models.InsightsMessage.REDACTED_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -20,10 +21,26 @@ public class InsightsMessageTest {
             + " -Dsome.broken.json=\"{\"a\":\"b\"'{\",";
     String sanitizedJvmArgs =
         "[-D[Standalone], -verbose:gc, -Xloggc:/opt/jboss-eap-7.4.0/standalone/log/gc.log,"
-            + " -Djava.net.preferIPv4Stack=*****, -Djboss.modules.system.pkgs=*****,"
-            + " -Djava.awt.headless=*****, -Dorg.jboss.boot.log.file=*****,"
-            + " -Dsome.dumb.practice=*****, -Dsome.broken.practice=*****, -Dsome.nice.json=*****,"
-            + " -Dsome.broken.json=*****,";
+            + " -Djava.net.preferIPv4Stack"
+            + REDACTED_VALUE
+            + ", -Djboss.modules.system.pkgs"
+            + REDACTED_VALUE
+            + ","
+            + " -Djava.awt.headless"
+            + REDACTED_VALUE
+            + ", -Dorg.jboss.boot.log.file"
+            + REDACTED_VALUE
+            + ","
+            + " -Dsome.dumb.practice"
+            + REDACTED_VALUE
+            + ", -Dsome.broken.practice"
+            + REDACTED_VALUE
+            + ", -Dsome.nice.json"
+            + REDACTED_VALUE
+            + ","
+            + " -Dsome.broken.json"
+            + REDACTED_VALUE
+            + ",";
 
     assertEquals(sanitizedJvmArgs, InsightsMessage.sanitizeJavaParameters(unsanitizedJvmArgs));
   }

--- a/core/src/test/java/com/redhat/runtimes/inventory/models/InsightsMessageTest.java
+++ b/core/src/test/java/com/redhat/runtimes/inventory/models/InsightsMessageTest.java
@@ -44,4 +44,34 @@ public class InsightsMessageTest {
 
     assertEquals(sanitizedJvmArgs, InsightsMessage.sanitizeJavaParameters(unsanitizedJvmArgs));
   }
+
+  // This test is to ensure that we don't have any impact when we sanitize the JVM args on both
+  // client and server side
+  @Test
+  public void testDoubleSanitizeJavaParametersIsANoop() {
+    String sanitizedJvmArgs =
+        "[-D[Standalone], -verbose:gc, -Xloggc:/opt/jboss-eap-7.4.0/standalone/log/gc.log,"
+            + " -Djava.net.preferIPv4Stack"
+            + REDACTED_VALUE
+            + ", -Djboss.modules.system.pkgs"
+            + REDACTED_VALUE
+            + ","
+            + " -Djava.awt.headless"
+            + REDACTED_VALUE
+            + ", -Dorg.jboss.boot.log.file"
+            + REDACTED_VALUE
+            + ","
+            + " -Dsome.dumb.practice"
+            + REDACTED_VALUE
+            + ", -Dsome.broken.practice"
+            + REDACTED_VALUE
+            + ", -Dsome.nice.json"
+            + REDACTED_VALUE
+            + ","
+            + " -Dsome.broken.json"
+            + REDACTED_VALUE
+            + ",";
+
+    assertEquals(sanitizedJvmArgs, InsightsMessage.sanitizeJavaParameters(sanitizedJvmArgs));
+  }
 }

--- a/core/src/test/java/com/redhat/runtimes/inventory/models/InsightsMessageTest.java
+++ b/core/src/test/java/com/redhat/runtimes/inventory/models/InsightsMessageTest.java
@@ -1,4 +1,30 @@
 /* Copyright (C) Red Hat 2023 */
 package com.redhat.runtimes.inventory.models;
 
-public class InsightsMessageTest {}
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class InsightsMessageTest {
+
+  @Test
+  public void testSanitizeJavaParameters() {
+    String unsanitizedJvmArgs =
+        "[-D[Standalone], -verbose:gc, -Xloggc:/opt/jboss-eap-7.4.0/standalone/log/gc.log,"
+            + " -Djava.net.preferIPv4Stack=true, -Djboss.modules.system.pkgs=org.jboss.byteman,"
+            + " -Djava.awt.headless=true,"
+            + " -Dorg.jboss.boot.log.file=/opt/jboss-eap-7.4.0/standalone/log/server.log,"
+            + " -Dsome.dumb.practice=\"Man I hope \\\" ' this = works\","
+            + " -Dsome.broken.practice=\"Man I hope ' '{ this still = works\","
+            + " -Dsome.nice.json=\"{\"a\":\"b\"}\","
+            + " -Dsome.broken.json=\"{\"a\":\"b\"'{\",";
+    String sanitizedJvmArgs =
+        "[-D[Standalone], -verbose:gc, -Xloggc:/opt/jboss-eap-7.4.0/standalone/log/gc.log,"
+            + " -Djava.net.preferIPv4Stack=*****, -Djboss.modules.system.pkgs=*****,"
+            + " -Djava.awt.headless=*****, -Dorg.jboss.boot.log.file=*****,"
+            + " -Dsome.dumb.practice=*****, -Dsome.broken.practice=*****, -Dsome.nice.json=*****,"
+            + " -Dsome.broken.json=*****,";
+
+    assertEquals(sanitizedJvmArgs, InsightsMessage.sanitizeJavaParameters(unsanitizedJvmArgs));
+  }
+}

--- a/core/src/test/java/com/redhat/runtimes/inventory/models/InsightsMessageTest.java
+++ b/core/src/test/java/com/redhat/runtimes/inventory/models/InsightsMessageTest.java
@@ -1,0 +1,4 @@
+/* Copyright (C) Red Hat 2023 */
+package com.redhat.runtimes.inventory.models;
+
+public class InsightsMessageTest {}

--- a/events/pom.xml
+++ b/events/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.23.0</version>
+      <version>1.24.0</version>
     </dependency>
 
     <!-- Quarkus -->

--- a/events/src/main/java/com/redhat/runtimes/inventory/events/Utils.java
+++ b/events/src/main/java/com/redhat/runtimes/inventory/events/Utils.java
@@ -429,10 +429,8 @@ public final class Utils {
   public static String sanitizeJavaParameters(String in) {
     StringBuilder out = new StringBuilder();
     String redacted = "=*****"; // What to replace sanitized content with
-    Log.info(in);
 
     for (String token : tokenizeString(in)) {
-      Log.info(token);
       // We only care about -Dxxxxx=yyyyy params
       if (token.startsWith("-D") && token.contains("=")) {
         String[] parts = token.split("=", 2);

--- a/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerTest.java
+++ b/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerTest.java
@@ -5,6 +5,7 @@ import static com.redhat.runtimes.inventory.events.TestUtils.inputStreamFromReso
 import static com.redhat.runtimes.inventory.events.TestUtils.readBytesFromResources;
 import static com.redhat.runtimes.inventory.events.TestUtils.readFromResources;
 import static com.redhat.runtimes.inventory.events.Utils.instanceOf;
+import static com.redhat.runtimes.inventory.models.InsightsMessage.REDACTED_VALUE;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -63,9 +64,9 @@ public class EventConsumerTest {
     assertEquals(hostname, inst.getHostname());
 
     // Check that sanitizing is happening
-    assertTrue(inst.getJvmArgs().contains("=*****"));
+    assertTrue(inst.getJvmArgs().contains(REDACTED_VALUE));
     // This example file doesn't have anything to sanitize here
-    // assertTrue(inst.getJavaCommand().contains("=*****"));
+    // assertTrue(inst.getJavaCommand().contains(REDACTED_VALUE));
   }
 
   @Test
@@ -108,8 +109,8 @@ public class EventConsumerTest {
     assertNotNull(inst.getConfiguration().getSocketBindingGroups());
 
     // Check that sanitizing is happening
-    assertTrue(inst.getJvmArgs().contains("=*****"));
-    assertTrue(inst.getJavaCommand().contains("=*****"));
+    assertTrue(inst.getJvmArgs().contains(REDACTED_VALUE));
+    assertTrue(inst.getJavaCommand().contains(REDACTED_VALUE));
   }
 
   @Test
@@ -158,11 +159,25 @@ public class EventConsumerTest {
         "[-D[Standalone], -verbose:gc, -Xloggc:/opt/jboss-eap-7.4.0/standalone/log/gc.log,"
             + " -XX:+PrintGCDetails, -XX:+PrintGCDateStamps, -XX:+UseGCLogFileRotation,"
             + " -XX:NumberOfGCLogFiles=5, -XX:GCLogFileSize=3M, -XX:-TraceClassUnloading,"
-            + " -Djdk.serialFilter=*****, -Xms1303m, -Xmx2048m, -XX:MetaspaceSize=128M,"
-            + " -XX:MaxMetaspaceSize=512m, -Djava.net.preferIPv4Stack=*****,"
-            + " -Djboss.modules.system.pkgs=*****, -Djava.awt.headless=*****,"
-            + " -Dorg.jboss.boot.log.file=*****, -Dsome.dumb.practice=*****,"
-            + " -Dlogging.configuration=*****]";
+            + " -Djdk.serialFilter"
+            + REDACTED_VALUE
+            + ", -Xms1303m, -Xmx2048m, -XX:MetaspaceSize=128M,"
+            + " -XX:MaxMetaspaceSize=512m, -Djava.net.preferIPv4Stack"
+            + REDACTED_VALUE
+            + ","
+            + " -Djboss.modules.system.pkgs"
+            + REDACTED_VALUE
+            + ", -Djava.awt.headless"
+            + REDACTED_VALUE
+            + ","
+            + " -Dorg.jboss.boot.log.file"
+            + REDACTED_VALUE
+            + ", -Dsome.dumb.practice"
+            + REDACTED_VALUE
+            + ","
+            + " -Dlogging.configuration"
+            + REDACTED_VALUE
+            + "]";
 
     String unsanitizedJavaCommand =
         "/opt/jboss/7/eap/jboss-modules.jar -mp"
@@ -173,8 +188,13 @@ public class EventConsumerTest {
     String sanitizedJavaCommand =
         "/opt/jboss/7/eap/jboss-modules.jar -mp"
             + " /opt/jboss/7/eap/modules:/opt/jboss/7/eap/../modules org.jboss.as.standalone"
-            + " -Djboss.home.dir=***** -Djboss.server.base.dir=***** -c standalone.xml"
-            + " -Djboss.server.base.dir=*****";
+            + " -Djboss.home.dir"
+            + REDACTED_VALUE
+            + " -Djboss.server.base.dir"
+            + REDACTED_VALUE
+            + " -c standalone.xml"
+            + " -Djboss.server.base.dir"
+            + REDACTED_VALUE;
 
     inst.setJvmArgs(unsanitizedJvmArgs);
     inst.setJavaCommand(unsanitizedJavaCommand);

--- a/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerTest.java
+++ b/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerTest.java
@@ -5,7 +5,6 @@ import static com.redhat.runtimes.inventory.events.TestUtils.inputStreamFromReso
 import static com.redhat.runtimes.inventory.events.TestUtils.readBytesFromResources;
 import static com.redhat.runtimes.inventory.events.TestUtils.readFromResources;
 import static com.redhat.runtimes.inventory.events.Utils.instanceOf;
-import static com.redhat.runtimes.inventory.events.Utils.sanitizeInstance;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -180,7 +179,7 @@ public class EventConsumerTest {
     inst.setJvmArgs(unsanitizedJvmArgs);
     inst.setJavaCommand(unsanitizedJavaCommand);
 
-    sanitizeInstance(inst);
+    inst.sanitize();
 
     assertEquals(sanitizedJvmArgs, inst.getJvmArgs());
     assertEquals(sanitizedJavaCommand, inst.getJavaCommand());

--- a/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerTest.java
+++ b/events/src/test/java/com/redhat/runtimes/inventory/events/EventConsumerTest.java
@@ -65,6 +65,8 @@ public class EventConsumerTest {
 
     // Check that sanitizing is happening
     assertTrue(inst.getJvmArgs().contains("=*****"));
+    // This example file doesn't have anything to sanitize here
+    // assertTrue(inst.getJavaCommand().contains("=*****"));
   }
 
   @Test
@@ -108,6 +110,7 @@ public class EventConsumerTest {
 
     // Check that sanitizing is happening
     assertTrue(inst.getJvmArgs().contains("=*****"));
+    assertTrue(inst.getJavaCommand().contains("=*****"));
   }
 
   @Test


### PR DESCRIPTION
This is based on @aslicerh original PR, but has been refactored to make it slightly more OO.

I've also changed the redacted value to something that doesn't contain * chars that might cause match scripts to choke or require excessive escaping.

Given that this has a homebrew embedded state machine, it needs a proper test suite soon.