### PR TITLE
feat: add SLO for rest metrics

### DIFF
--- a/events/src/main/java/com/redhat/runtimes/inventory/events/MetricsConfiguration.java
+++ b/events/src/main/java/com/redhat/runtimes/inventory/events/MetricsConfiguration.java
@@ -16,12 +16,12 @@ public class MetricsConfiguration {
   @ConfigProperty(
       name = "metrics.event.processing.duration.minimumExpectedValue",
       defaultValue = "1")
-  private Integer minimumExpectedValue;
+  Integer minimumExpectedValue;
 
   @ConfigProperty(
       name = "metrics.event.processing.duration.maximumExpectedValue",
       defaultValue = "150")
-  private Integer maximumExpectedValue;
+  Integer maximumExpectedValue;
 
   @Produces
   @Singleton

--- a/events/src/main/java/com/redhat/runtimes/inventory/events/MetricsConfiguration.java
+++ b/events/src/main/java/com/redhat/runtimes/inventory/events/MetricsConfiguration.java
@@ -1,0 +1,39 @@
+/* Copyright (C) Red Hat 2023 */
+package com.redhat.runtimes.inventory.events;
+
+import static com.redhat.runtimes.inventory.events.EventConsumer.CONSUMED_TIMER_NAME;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+import java.util.List;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Singleton
+public class MetricsConfiguration {
+
+  @ConfigProperty(name = "metrics.events.slo", defaultValue = "150,500,1000,5000")
+  List<Integer> slo;
+
+  @Produces
+  @Singleton
+  public MeterFilter enableHistogram() {
+    return new MeterFilter() {
+      @Override
+      public DistributionStatisticConfig configure(
+          Meter.Id id, DistributionStatisticConfig config) {
+        if (id.getName().startsWith(CONSUMED_TIMER_NAME)) {
+          // convert to nanoseconds
+          double[] values = slo.stream().map(i -> i * 1_000_000d).mapToDouble(d -> d).toArray();
+          return DistributionStatisticConfig.builder()
+              .serviceLevelObjectives(values)
+              .build()
+              .merge(config);
+        }
+        return config;
+      }
+    };
+  }
+}

--- a/rest/src/main/java/com/redhat/runtimes/inventory/web/MetricsConfiguration.java
+++ b/rest/src/main/java/com/redhat/runtimes/inventory/web/MetricsConfiguration.java
@@ -12,10 +12,10 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 public class MetricsConfiguration {
 
   @ConfigProperty(name = "request.processing.duration.minimumExpectedValue", defaultValue = "1")
-  private Integer minimumExpectedValue;
+  Integer minimumExpectedValue;
 
   @ConfigProperty(name = "request.processing.duration.maximumExpectedValue", defaultValue = "700")
-  private Integer maximumExpectedValue;
+  Integer maximumExpectedValue;
 
   @Produces
   @Singleton

--- a/rest/src/main/java/com/redhat/runtimes/inventory/web/MetricsConfiguration.java
+++ b/rest/src/main/java/com/redhat/runtimes/inventory/web/MetricsConfiguration.java
@@ -1,0 +1,37 @@
+/* Copyright (C) Red Hat 2023 */
+package com.redhat.runtimes.inventory.web;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+import java.util.List;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Singleton
+public class MetricsConfiguration {
+
+  @ConfigProperty(name = "metrics.https.request.slo", defaultValue = "150,500,1000,5000")
+  List<Integer> slo;
+
+  @Produces
+  @Singleton
+  public MeterFilter enableHistogram() {
+    return new MeterFilter() {
+      @Override
+      public DistributionStatisticConfig configure(
+          Meter.Id id, DistributionStatisticConfig config) {
+        if (id.getName().startsWith("http.server.requests")) {
+          // convert to nanoseconds
+          double[] values = slo.stream().map(i -> i * 1_000_000d).mapToDouble(d -> d).toArray();
+          return DistributionStatisticConfig.builder()
+              .serviceLevelObjectives(values)
+              .build()
+              .merge(config);
+        }
+        return config;
+      }
+    };
+  }
+}


### PR DESCRIPTION
This defines the buckets so we can set rules based on percentiles. (histograms)