### PR TITLE
Modify Cryostat resource requests/limit ratio

### DIFF
--- a/deploy/cryostat.yml
+++ b/deploy/cryostat.yml
@@ -222,7 +222,7 @@ objects:
             resources:
               requests:
                 cpu: "500m"
-                memory: "256Mi"
+                memory: "512Mi"
               limits:
                 cpu: "1"
                 memory: "1Gi"
@@ -270,7 +270,7 @@ objects:
             resources:
               requests:
                 cpu: "100m"
-                memory: "120Mi"
+                memory: "128Mi"
               limits:
                 cpu: "200m"
                 memory: "256Mi"
@@ -296,8 +296,8 @@ objects:
                   - http://127.0.0.1:8080
             resources:
               requests:
-                cpu: "200m"
-                memory: "384Mi"
+                cpu: "300m"
+                memory: "512Mi"
               limits:
                 cpu: "600m"
                 memory: "1Gi"


### PR DESCRIPTION
I noticed the following error when attempting to scale up a replica set in Ephemeral:
```
Error creating: pods "cryostat-6cbc56f887-bxp72" is forbidden: memory max limit to request ratio per Pod is 2, but provided ratio is 3.031579
```
This PR adjusts all resource requests/limits so the ratio is 2.