### PR TITLE
Require authentication for remote JMX connections

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -51,9 +51,21 @@ objects:
             volumeMounts:
               - mountPath: /tmp
                 name: tmpdir
+              - mountPath: /var/run/secrets/com.redhat.insights/jmx-auth
+                name: jmx-auth
+                readOnly: true
             volumes:
               - emptyDir: {}
                 name: tmpdir
+              - name: jmx-auth
+                secret:
+                  secretName: runtimes-inventory-jmx-auth
+                  items:
+                    - key: access
+                      path: jmxremote.access
+                    - key: password
+                      path: jmxremote.password
+                  optional: true
             env:
               - name: QUARKUS_PROFILE
                 value: ${ENV_NAME}
@@ -61,6 +73,10 @@ objects:
                 value: ${CLOUDWATCH_ENABLED}
               - name: CRYOSTAT_JAVA_OPTS
                 value: "${CRYOSTAT_JAVA_OPTS}"
+              - name: CRYOSTAT_JMX_ACCESS_FILE
+                value: /var/run/secrets/com.redhat.insights/jmx-auth/jmxremote.access
+              - name: CRYOSTAT_JMX_PASSWORD_FILE
+                value: /var/run/secrets/com.redhat.insights/jmx-auth/jmxremote.password
           webServices:
             metrics: {}
             private: {}
@@ -104,9 +120,21 @@ objects:
             volumeMounts:
               - mountPath: /tmp
                 name: tmpdir
+              - mountPath: /var/run/secrets/com.redhat.insights/jmx-auth
+                name: jmx-auth
+                readOnly: true
             volumes:
               - emptyDir: {}
                 name: tmpdir
+              - name: jmx-auth
+                secret:
+                  secretName: runtimes-inventory-jmx-auth
+                  items:
+                    - key: access
+                      path: jmxremote.access
+                    - key: password
+                      path: jmxremote.password
+                  optional: true
             env:
               - name: QUARKUS_PROFILE
                 value: ${ENV_NAME}
@@ -114,6 +142,10 @@ objects:
                 value: ${CLOUDWATCH_ENABLED}
               - name: CRYOSTAT_JAVA_OPTS
                 value: "${CRYOSTAT_JAVA_OPTS}"
+              - name: CRYOSTAT_JMX_ACCESS_FILE
+                value: /var/run/secrets/com.redhat.insights/jmx-auth/jmxremote.access
+              - name: CRYOSTAT_JMX_PASSWORD_FILE
+                value: /var/run/secrets/com.redhat.insights/jmx-auth/jmxremote.password
           webServices:
             metrics: {}
             private: {}
@@ -154,6 +186,16 @@ objects:
         - protocol: TCP
           port: 9091
           targetPort: 9091
+
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: runtimes-inventory-jmx-auth
+    type: Opaque
+    stringData:
+      access: "admin readwrite"
+      password: "admin ${EPHEMERAL_JMX_PASSWORD}"
+
 parameters:
   - name: IMAGE_TAG
     value: latest
@@ -173,3 +215,8 @@ parameters:
   - name: CRYOSTAT_JAVA_OPTS
     value: ""
     displayName: Java system properties for Cryostat support
+  - name: EPHEMERAL_JMX_PASSWORD
+    displayName: Remote JMX Password (Ephemeral Only)
+    description: Password to connect over remote JMX on Ephemeral Environments
+    generate: expression
+    from: '[\w]{10}'

--- a/deploy/docker/common/cryostat-run-env.sh
+++ b/deploy/docker/common/cryostat-run-env.sh
@@ -1,5 +1,23 @@
 #!/bin/sh
 
+# Append any Cryostat-specific options to JAVA_OPTS_APPEND
 if [ -n "${CRYOSTAT_JAVA_OPTS}" ]; then
+  # Java requires the JMX credentials file to be readable only by the
+  # JVM process owner. Because OpenShift uses arbitrary UIDs when running
+  # containers, we need to copy the file to change ownership and then
+  # reduce its permissions.
+  if [ -n "${CRYOSTAT_JMX_PASSWORD_FILE}" ] && [ -n "${CRYOSTAT_JMX_ACCESS_FILE}" ]; then
+      tmpdir="$(mktemp -d)"
+      passwordFile="${tmpdir}/jmxremote.password"
+      cp "${CRYOSTAT_JMX_PASSWORD_FILE}" "${passwordFile}"
+      chmod 400 "${passwordFile}"
+      accessFile="${tmpdir}/jmxremote.access"
+      cp "${CRYOSTAT_JMX_ACCESS_FILE}" "${accessFile}"
+      chmod 400 "${accessFile}"
+      CRYOSTAT_JAVA_OPTS="${CRYOSTAT_JAVA_OPTS} \
+        -Dcom.sun.management.jmxremote.password.file=${passwordFile} \
+        -Dcom.sun.management.jmxremote.access.file=${accessFile}"
+  fi
+
   export JAVA_OPTS_APPEND="${JAVA_OPTS_APPEND} ${CRYOSTAT_JAVA_OPTS}"
 fi


### PR DESCRIPTION
This PR adds password protection for remote JMX connections to the runtimes-inventory pods. The credentials are located in a Kubernetes secret. On ephemeral environments this secret is created with the OpenShift template using a generated password. On stage and prod, these secrets will come from elsewhere.