### PR TITLE
Use TLS for remote JMX connections

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -54,6 +54,11 @@ objects:
               - mountPath: /var/run/secrets/com.redhat.insights/jmx-auth
                 name: jmx-auth
                 readOnly: true
+              - mountPath: /var/run/secrets/com.redhat.insights/jmx-tls
+                name: jmx-tls
+                readOnly: true
+              - name: keystore-volume
+                mountPath: /var/run/secrets/com.redhat.insights/jmx-keystore
             volumes:
               - emptyDir: {}
                 name: tmpdir
@@ -66,17 +71,50 @@ objects:
                     - key: password
                       path: jmxremote.password
                   optional: true
+              - name: jmx-tls
+                secret:
+                  secretName: runtimes-inventory-service-cryostat-tls
+                  optional: true
+              - name: keystore-volume
+                emptyDir: {}
             env:
               - name: QUARKUS_PROFILE
                 value: ${ENV_NAME}
               - name: QUARKUS_LOG_CLOUDWATCH_ENABLED
                 value: ${CLOUDWATCH_ENABLED}
-              - name: CRYOSTAT_JAVA_OPTS
-                value: "${CRYOSTAT_JAVA_OPTS}"
               - name: CRYOSTAT_JMX_ACCESS_FILE
                 value: /var/run/secrets/com.redhat.insights/jmx-auth/jmxremote.access
               - name: CRYOSTAT_JMX_PASSWORD_FILE
                 value: /var/run/secrets/com.redhat.insights/jmx-auth/jmxremote.password
+              - name: CRYOSTAT_KEYSTORE_FILE
+                value: /var/run/secrets/com.redhat.insights/jmx-keystore/keystore.p12
+              - name: CRYOSTAT_KEYSTORE_PASS
+                valueFrom:
+                  secretKeyRef:
+                    name: runtimes-inventory-keystore-pass
+                    key: KEYSTORE_PASS
+              - name: CRYOSTAT_JAVA_OPTS
+                value: "${CRYOSTAT_JAVA_OPTS}"
+            initContainers:
+              - name: pem-to-keystore
+                image: registry.access.redhat.com/ubi8/openssl:${OPENSSL_IMAGE_TAG}
+                env:
+                  - name: KEY_FILE
+                    value: /var/run/secrets/com.redhat.insights/jmx-tls/tls.key
+                  - name: CERT_FILE
+                    value: /var/run/secrets/com.redhat.insights/jmx-tls/tls.crt
+                  - name: KEYSTORE_FILE
+                    value: /var/run/secrets/com.redhat.insights/jmx-keystore/keystore.p12
+                  - name: KEYSTORE_PASS
+                    valueFrom:
+                      secretKeyRef:
+                        name: runtimes-inventory-keystore-pass
+                        key: KEYSTORE_PASS
+                command:
+                  - /bin/bash
+                args:
+                  - -c
+                  - openssl pkcs12 -export -inkey "${KEY_FILE}" -in "${CERT_FILE}" -out "${KEYSTORE_FILE}" -password "pass:${KEYSTORE_PASS}"
           webServices:
             metrics: {}
             private: {}
@@ -123,6 +161,11 @@ objects:
               - mountPath: /var/run/secrets/com.redhat.insights/jmx-auth
                 name: jmx-auth
                 readOnly: true
+              - mountPath: /var/run/secrets/com.redhat.insights/jmx-tls
+                name: jmx-tls
+                readOnly: true
+              - name: keystore-volume
+                mountPath: /var/run/secrets/com.redhat.insights/jmx-keystore
             volumes:
               - emptyDir: {}
                 name: tmpdir
@@ -135,6 +178,12 @@ objects:
                     - key: password
                       path: jmxremote.password
                   optional: true
+              - name: jmx-tls
+                secret:
+                  secretName: runtimes-inventory-rest-cryostat-tls
+                  optional: true
+              - name: keystore-volume
+                emptyDir: {}
             env:
               - name: QUARKUS_PROFILE
                 value: ${ENV_NAME}
@@ -146,6 +195,35 @@ objects:
                 value: /var/run/secrets/com.redhat.insights/jmx-auth/jmxremote.access
               - name: CRYOSTAT_JMX_PASSWORD_FILE
                 value: /var/run/secrets/com.redhat.insights/jmx-auth/jmxremote.password
+              - name: CRYOSTAT_KEYSTORE_FILE
+                value: /var/run/secrets/com.redhat.insights/jmx-keystore/keystore.p12
+              - name: CRYOSTAT_KEYSTORE_PASS
+                valueFrom:
+                  secretKeyRef:
+                    name: runtimes-inventory-keystore-pass
+                    key: KEYSTORE_PASS
+              - name: CRYOSTAT_JAVA_OPTS
+                value: "${CRYOSTAT_JAVA_OPTS}"
+            initContainers:
+              - name: pem-to-keystore
+                image: registry.access.redhat.com/ubi8/openssl:${OPENSSL_IMAGE_TAG}
+                env:
+                  - name: KEY_FILE
+                    value: /var/run/secrets/com.redhat.insights/jmx-tls/tls.key
+                  - name: CERT_FILE
+                    value: /var/run/secrets/com.redhat.insights/jmx-tls/tls.crt
+                  - name: KEYSTORE_FILE
+                    value: /var/run/secrets/com.redhat.insights/jmx-keystore/keystore.p12
+                  - name: KEYSTORE_PASS
+                    valueFrom:
+                      secretKeyRef:
+                        name: runtimes-inventory-keystore-pass
+                        key: KEYSTORE_PASS
+                command:
+                  - /bin/bash
+                args:
+                  - -c
+                  - openssl pkcs12 -export -inkey "${KEY_FILE}" -in "${CERT_FILE}" -out "${KEYSTORE_FILE}" -password "pass:${KEYSTORE_PASS}"
           webServices:
             metrics: {}
             private: {}
@@ -168,6 +246,8 @@ objects:
     kind: Service
     metadata:
       name: runtimes-inventory-service-cryostat
+      annotations:
+        service.beta.openshift.io/serving-cert-secret-name: runtimes-inventory-service-cryostat-tls
     spec:
       selector:
         pod: runtimes-inventory-service
@@ -179,6 +259,8 @@ objects:
     kind: Service
     metadata:
       name: runtimes-inventory-rest-cryostat
+      annotations:
+        service.beta.openshift.io/serving-cert-secret-name: runtimes-inventory-rest-cryostat-tls
     spec:
       selector:
         pod: runtimes-inventory-rest
@@ -195,6 +277,13 @@ objects:
     stringData:
       access: "admin readwrite"
       password: "admin ${EPHEMERAL_JMX_PASSWORD}"
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: runtimes-inventory-keystore-pass
+    type: Opaque
+    stringData:
+      KEYSTORE_PASS: "${EPHEMERAL_KEYSTORE_PASSWORD}"
 
 parameters:
   - name: IMAGE_TAG
@@ -213,10 +302,25 @@ parameters:
     value: "1"
     displayName: Minimum number of replicas for deployments
   - name: CRYOSTAT_JAVA_OPTS
-    value: ""
+    value: >-
+      -Dcom.sun.management.jmxremote.port=9091
+      -Dcom.sun.management.jmxremote.ssl=true
+      -Dcom.sun.management.jmxremote.registry.ssl=true
+      -Dcom.sun.management.jmxremote.authenticate=true
+      -Djavax.net.ssl.keyStore=$(CRYOSTAT_KEYSTORE_FILE)
+      -Djavax.net.ssl.keyStorePassword=$(CRYOSTAT_KEYSTORE_PASS)
     displayName: Java system properties for Cryostat support
+  - name: OPENSSL_IMAGE_TAG
+    displayName: OpenSSL UBI8 image tag
+    description: Image tag for the OpenSSL init container
+    value: "8.9-8"
   - name: EPHEMERAL_JMX_PASSWORD
     displayName: Remote JMX Password (Ephemeral Only)
     description: Password to connect over remote JMX on Ephemeral Environments
+    generate: expression
+    from: '[\w]{10}'
+  - name: EPHEMERAL_KEYSTORE_PASSWORD
+    displayName: Keystore Password (Ephemeral Only)
+    description: Password for the Keystore used by the remote JMX server on Ephemeral Environments
     generate: expression
     from: '[\w]{10}'

--- a/deploy/cryostat.yml
+++ b/deploy/cryostat.yml
@@ -246,6 +246,9 @@ objects:
                 name: basic-auth-properties
                 subPath: cryostat-users.properties
                 readOnly: true
+              - mountPath: /truststore/openshift
+                name: trusted-certs
+                readOnly: true
           - name: cryostat-grafana
             securityContext:
               allowPrivilegeEscalation: false
@@ -311,6 +314,15 @@ objects:
               items:
                 - key: properties
                   path: cryostat-users.properties
+          - name: trusted-certs
+            projected:
+              sources:
+                - configMap:
+                    name: cryostat-ca-bundle
+                    items:
+                      - key: service-ca.crt
+                        path: openshift-ca-bundle.crt
+                        mode: 0440
 
 - apiVersion: route.openshift.io/v1
   kind: Route
@@ -362,6 +374,17 @@ objects:
     resources:
       requests:
         storage: "${CRYOSTAT_STORAGE_SIZE}"
+
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: cryostat-ca-bundle
+    labels:
+      app.kubernetes.io/name: cryostat
+      app.kubernetes.io/instance: cryostat
+      app.kubernetes.io/version: "2.3.1.redhat"
+    annotations:
+      service.beta.openshift.io/inject-cabundle: "true"
 
 - apiVersion: v1
   kind: Secret

--- a/deploy/docker/common/cryostat-run-env.sh
+++ b/deploy/docker/common/cryostat-run-env.sh
@@ -6,7 +6,7 @@ if [ -n "${CRYOSTAT_JAVA_OPTS}" ]; then
   # JVM process owner. Because OpenShift uses arbitrary UIDs when running
   # containers, we need to copy the file to change ownership and then
   # reduce its permissions.
-  if [ -n "${CRYOSTAT_JMX_PASSWORD_FILE}" ] && [ -n "${CRYOSTAT_JMX_ACCESS_FILE}" ]; then
+  if [ -f "${CRYOSTAT_JMX_PASSWORD_FILE}" ] && [ -f "${CRYOSTAT_JMX_ACCESS_FILE}" ]; then
       tmpdir="$(mktemp -d)"
       passwordFile="${tmpdir}/jmxremote.password"
       cp "${CRYOSTAT_JMX_PASSWORD_FILE}" "${passwordFile}"


### PR DESCRIPTION
This PR configures the runtimes-inventory pods to use TLS for remote JMX connections. OpenShift's [service serving certificates](https://docs.openshift.com/container-platform/4.14/security/certificates/service-serving-certificate.html) provide the key and certificate.

In order to be usable by Java, the key and certificate need to be added to a keystore. Since Keytool doesn't provide a way to import an existing key into a keystore, I used OpenSSL for this based on this old Red Hat Developer [article](https://developers.redhat.com/blog/2017/11/22/dynamically-creating-java-keystores-openshift#consuming_dynamically_generated_certificates_from_java_applications). This has to be done using an init container that simply runs an OpenSSL command to generate the keystore for use by the main container. I opted for the OpenSSL UBI image that works well for this purpose.

A new Config Map is mounted into the Cryostat container. This Config Map is populated by OpenShift with the CA bundle used to sign the generated certificate. The Config Map is mounted at a location where Cryostat knows to add the CA bundle into its truststore.

I tested this in an Ephemeral Environment and it worked as expected.